### PR TITLE
Post photometry to skyportal in flux space and handle negative fluxes

### DIFF
--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -125,6 +125,42 @@ def make_photometry(alert: dict, jd_start: float = None):
     mask_good_diffmaglim = df_light_curve["diffmaglim"] > 0
     df_light_curve = df_light_curve.loc[mask_good_diffmaglim]
 
+    # convert from mag to flux
+
+    # step 1: calculate the coefficient that determines whether the
+    # flux should be negative or positive
+    coeff = df_light_curve["isdiffpos"].apply(
+        lambda x: 1.0 if x in [True, 1, "y", "Y"] else -1.0
+    )
+
+    # step 2: calculate the flux normalized to an arbitrary AB zeropoint of
+    # 23.9 (results in flux in uJy)
+    df_light_curve["flux"] = coeff * 10 ** (-0.4 * (df_light_curve["magpsf"] - 23.9))
+
+    # step 3: separate detections from non detections
+    detected = np.isfinite(df_light_curve["magpsf"])
+    undetected = ~detected
+
+    # step 4: calculate the flux error
+    df_light_curve["fluxerr"] = None  # initialize the column
+
+    # step 4a: calculate fluxerr for detections using sigmapsf
+    df_light_curve.loc[detected, "fluxerr"] = np.abs(
+        df_light_curve.loc[detected, "sigmapsf"]
+        * df_light_curve.loc[detected, "flux"]
+        * np.log(10)
+        / 2.5
+    )
+
+    # step 4b: calculate fluxerr for non detections using diffmaglim
+    df_light_curve.loc[undetected, "fluxerr"] = (
+        10 ** (-0.4 * (df_light_curve.loc[undetected, "diffmaglim"] - 23.9)) / 5.0
+    )  # as diffmaglim is the 5-sigma depth
+
+    # step 5: set the zeropoint and magnitude system
+    df_light_curve["zp"] = 23.9
+    df_light_curve["zpsys"] = "ab"
+
     # only "new" photometry requested?
     if jd_start is not None:
         w_after_jd = df_light_curve["jd"] > jd_start
@@ -1300,10 +1336,10 @@ class AlertWorker:
                     "group_ids": group_ids,
                     "instrument_id": self.instrument_id,
                     "mjd": df_photometry.loc[pid_mask, "mjd"].tolist(),
-                    "mag": df_photometry.loc[pid_mask, "magpsf"].tolist(),
-                    "magerr": df_photometry.loc[pid_mask, "sigmapsf"].tolist(),
-                    "limiting_mag": df_photometry.loc[pid_mask, "diffmaglim"].tolist(),
-                    "magsys": df_photometry.loc[pid_mask, "magsys"].tolist(),
+                    "flux": df_photometry.loc[pid_mask, "flux"].tolist(),
+                    "fluxerr": df_photometry.loc[pid_mask, "fluxerr"].tolist(),
+                    "zp": df_photometry.loc[pid_mask, "zp"].tolist(),
+                    "magsys": df_photometry.loc[pid_mask, "zpsys"].tolist(),
                     "filter": df_photometry.loc[pid_mask, "ztf_filter"].tolist(),
                     "ra": df_photometry.loc[pid_mask, "ra"].tolist(),
                     "dec": df_photometry.loc[pid_mask, "dec"].tolist(),


### PR DESCRIPTION
Requesting review from @profjsb (can't request him as a reviewer formally)

This PR

1. Modifies the `make_photometry` function to convert photometry from magnitude space to flux space. Photometry from negative difference images is given a negative sign in flux space, gracefully handling negative photometry for variable sources and transients with reference image flux. 

2. Modifies the `alert_put_photometry` function to PUT the photometry to skyportal in flux space. 