### PR TITLE
Improve thumbnail scaling

### DIFF
--- a/kowalski/alert_watcher_ztf.py
+++ b/kowalski/alert_watcher_ztf.py
@@ -1,6 +1,7 @@
 import argparse
 from ast import literal_eval
 from astropy.io import fits
+from astropy.visualization import MinMaxInterval, LinearStretch, LogStretch, ImageNormalize
 import base64
 from bson.json_util import loads
 import confluent_kafka
@@ -9,7 +10,6 @@ import datetime
 import fastavro
 import gzip
 import io
-from matplotlib.colors import LogNorm
 import matplotlib.pyplot as plt
 import multiprocessing
 import numpy as np
@@ -172,11 +172,12 @@ def make_thumbnail(alert, ttype: str, ztftype: str):
     img = np.array(data_flipped_y)
     img = np.nan_to_num(img)
 
-    if ztftype != 'Difference':
-        img[img <= 0] = np.median(img)
-        plt.imshow(img, cmap="bone", norm=LogNorm(), origin='lower')
-    else:
-        plt.imshow(img, cmap="bone", origin='lower')
+    norm = ImageNormalize(
+        img,
+        interval=MinMaxInterval(),
+        stretch=LinearStretch() if ztftype == "Difference" else LogStretch()
+    )
+    ax.imshow(img, cmap="bone", origin='lower', norm=norm)
     plt.savefig(buff, dpi=42)
 
     buff.seek(0)

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2779,14 +2779,14 @@ async def ztf_alert_get_cutout(request):
         normalizer = normalization_methods.get(interval.lower(), MinMaxInterval())
 
         stretching_methods = {
-            'linear': LinearStretch(),
-            'log': LogStretch(),
-            'asinh': AsinhStretch(),
-            'sqrt': SqrtStretch(),
+            'linear': LinearStretch,
+            'log': LogStretch,
+            'asinh': AsinhStretch,
+            'sqrt': SqrtStretch,
         }
         if stretch is None:
             stretch = "log" if cutout != "Difference" else "linear"
-        stretcher = stretching_methods.get(stretch.lower(), LogStretch())
+        stretcher = stretching_methods.get(stretch.lower(), LogStretch)()
 
         if (cmap is None) or (cmap.lower() not in ['bone', 'gray', 'cividis', 'viridis', 'magma']):
             cmap = 'bone'

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2,7 +2,11 @@ import aiofiles
 from aiohttp import web
 from aiohttp_swagger3 import SwaggerDocs, ReDocUiSettings
 from astropy.io import fits
-from astropy.visualization import ZScaleInterval
+from astropy.visualization import (
+    MinMaxInterval, ZScaleInterval,
+    LinearStretch, LogStretch, AsinhStretch, SqrtStretch,
+    ImageNormalize
+)
 import asyncio
 from ast import literal_eval
 from bson.json_util import dumps, loads
@@ -2690,12 +2694,19 @@ async def ztf_alert_get_cutout(request):
           type: string
           enum: [fits, png]
       - in: query
-        name: scaling
-        description: "Scaling to use when rendering png"
+        name: interval
+        description: "Interval to use when rendering png"
         required: false
         schema:
           type: string
-          enum: [linear, log, arcsinh, zscale]
+          enum: [min_max, zscale]
+      - in: query
+        name: stretch
+        description: "Stretch to use when rendering png"
+        required: false
+        schema:
+          type: string
+          enum: [linear, log, asinh, sqrt]
       - in: query
         name: cmap
         description: "Color map to use when rendering png"
@@ -2740,7 +2751,8 @@ async def ztf_alert_get_cutout(request):
         candid = int(request.match_info['candid'])
         cutout = request.match_info['cutout'].capitalize()
         file_format = request.match_info['file_format']
-        scaling = request.query.get('scaling', None)
+        interval = request.query.get("interval")
+        stretch = request.query.get("stretch")
         cmap = request.query.get('cmap', None)
 
         known_cutouts = ['Science', 'Template', 'Difference']
@@ -2754,15 +2766,30 @@ async def ztf_alert_get_cutout(request):
                                       'message': f'file format {file_format} not in {str(known_file_formats)}'},
                                      status=400)
 
-        default_scaling = {
-            'Science': 'log',
-            'Template': 'log',
-            'Difference': 'linear'
-        }
-        if (scaling is None) or (scaling.lower() not in ('log', 'linear', 'zscale', 'arcsinh')):
-            scaling = default_scaling[cutout]
-        else:
-            scaling = scaling.lower()
+        if (interval is None) or (interval.lower() not in ['min_max', 'zscale']):
+            interval = MinMaxInterval()
+        elif interval.lower() == "min_max":
+            interval = MinMaxInterval()
+        elif interval.lower() == "zscale":
+            interval = ZScaleInterval(
+                nsamples=600,
+                contrast=0.045,
+                krej=2.5
+            )
+
+        if (stretch is None) or (stretch.lower() not in ["linear", "log", "asinh", "sqrt"]):
+            if cutout == "Difference":
+                stretch = LinearStretch()
+            else:
+                stretch = LogStretch()
+        elif stretch.lower() == "linear":
+            stretch = LinearStretch()
+        elif stretch.lower() == "log":
+            stretch = LogStretch()
+        elif stretch.lower() == "asinh":
+            stretch = AsinhStretch()
+        elif stretch.lower() == "sqrt":
+            stretch = SqrtStretch()
 
         if (cmap is None) or (cmap.lower() not in ['bone', 'gray', 'cividis', 'viridis', 'magma']):
             cmap = 'bone'
@@ -2808,21 +2835,12 @@ async def ztf_alert_get_cutout(request):
             img = np.array(data_flipped_y)
             img = np.nan_to_num(img)
 
-            if scaling == 'log':
-                img[img <= 0] = np.median(img)
-                ax.imshow(img, cmap=cmap, norm=LogNorm(), origin='lower')
-            elif scaling == 'linear':
-                ax.imshow(img, cmap=cmap, origin='lower')
-            elif scaling == 'zscale':
-                interval = ZScaleInterval(
-                    nsamples=img.shape[0] * img.shape[1],
-                    contrast=0.045,
-                    krej=2.5
-                )
-                limits = interval.get_limits(img)
-                ax.imshow(img, origin='lower', cmap=cmap, vmin=limits[0], vmax=limits[1])
-            elif scaling == 'arcsinh':
-                ax.imshow(np.arcsinh(img - np.median(img)), cmap=cmap, origin='lower')
+            norm = ImageNormalize(
+                img,
+                interval=interval,
+                stretch=stretch
+            )
+            ax.imshow(img, cmap=cmap, origin='lower', norm=norm)
 
             plt.savefig(buff, dpi=42)
 


### PR DESCRIPTION
This PR improves ZTF alert thumbnail scaling.

By default, K will use `astropy.visualization.MinMaxInterval()` and `astropy.visualization.LogStretch()` for `SCI` and `REF` cutouts. Other options are now also available.

Examples:

`ZTF20abjonjs` [top: after, bottom: before]
![image](https://user-images.githubusercontent.com/7557205/97761308-98889e80-1ac2-11eb-9fea-9f4ba398ee3a.png)


`ZTF20abyptpc` [top: after, bottom: before]
![image](https://user-images.githubusercontent.com/7557205/97761285-8870bf00-1ac2-11eb-9583-e0da48f18c33.png)

`ZTF20abyzoof` [top: after, bottom: before]
![image](https://user-images.githubusercontent.com/7557205/97761337-af2ef580-1ac2-11eb-988d-eda5efd8d2c5.png)

