### PR TITLE
Further thumbnail scaling improvements

### DIFF
--- a/kowalski/alert_watcher_ztf.py
+++ b/kowalski/alert_watcher_ztf.py
@@ -1,7 +1,7 @@
 import argparse
 from ast import literal_eval
 from astropy.io import fits
-from astropy.visualization import MinMaxInterval, LinearStretch, LogStretch, ImageNormalize
+from astropy.visualization import AsymmetricPercentileInterval, LinearStretch, LogStretch, ImageNormalize
 import base64
 from bson.json_util import loads
 import confluent_kafka
@@ -174,10 +174,15 @@ def make_thumbnail(alert, ttype: str, ztftype: str):
 
     norm = ImageNormalize(
         img,
-        interval=MinMaxInterval(),
         stretch=LinearStretch() if ztftype == "Difference" else LogStretch()
     )
-    ax.imshow(img, cmap="bone", origin='lower', norm=norm)
+    img_norm = norm(img)
+    normalizer = AsymmetricPercentileInterval(
+        lower_percentile=1,
+        upper_percentile=100
+    )
+    vmin, vmax = normalizer.get_limits(img_norm)
+    ax.imshow(img_norm, cmap="bone", origin='lower', vmin=vmin, vmax=vmax)
     plt.savefig(buff, dpi=42)
 
     buff.seek(0)


### PR DESCRIPTION
In this PR: 

Improve the contrast of the thumbnails.

For example:

ZTF20abjonjs:
![image](https://user-images.githubusercontent.com/7557205/97938877-6c298800-1d37-11eb-94f3-4496db475c01.png)

ZTF20acopavl:
![image](https://user-images.githubusercontent.com/7557205/97938920-882d2980-1d37-11eb-9c27-49ebda976f99.png)
vs what's there currently:
![image](https://user-images.githubusercontent.com/7557205/97938947-954a1880-1d37-11eb-85b2-2982f00baefe.png)

