### PR TITLE
Run ACAI models on incoming alerts

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -267,6 +267,14 @@ kowalski:
   ml_models:
     braai:
       version:  "d6_m9"
+    acai_h:
+      version: "d1_dnn_20201107"
+    acai_v:
+      version: "d1_dnn_20201109"
+    acai_o:
+      version: "d1_dnn_20201110"
+    acai_n:
+      version: "d1_dnn_20201110"
 
   skyportal:
     protocol: "http"

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -20,8 +20,13 @@ RUN apt-get update && apt-get install -y default-jdk && \
 # Kafka test-server properties:
 COPY kowalski/server.properties /kafka_$kafka_version/config/
 
-# ML models:
-ADD https://github.com/dmitryduev/braai/raw/master/models/braai_d6_m9.h5 /app/models/
+# ML models <model_name>.<tag>.<extensions>:
+ADD https://github.com/dmitryduev/braai/raw/master/models/braai_d6_m9.h5 /app/models/braai.d6_m9.h5
+ADD https://github.com/dmitryduev/acai-pub/raw/master/models/acai_h.d1_dnn_20201107.h5 /app/models/
+ADD https://github.com/dmitryduev/acai-pub/raw/master/models/acai_v.d1_dnn_20201109.h5 /app/models/
+ADD https://github.com/dmitryduev/acai-pub/raw/master/models/acai_o.d1_dnn_20201110.h5 /app/models/
+ADD https://github.com/dmitryduev/acai-pub/raw/master/models/acai_n.d1_dnn_20201110.h5 /app/models/
+ADD https://github.com/dmitryduev/acai-pub/raw/master/models/acai_b.d1_dnn_20201110.h5 /app/models/
 
 # copy over the test alerts
 COPY data/ztf_alerts/ /app/data/ztf_alerts/

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -337,7 +337,7 @@ def alert_filter__xmatch(database, alert) -> dict:
             xmatches[catalog] = list(s)
 
     except Exception as e:
-        print(time_stamp(), str(e))
+        log(str(e))
 
     return xmatches
 
@@ -460,7 +460,7 @@ def alert_filter__xmatch_clu(
         xmatches[clu_version] = matches
 
     except Exception as e:
-        print(time_stamp(), str(e))
+        log(str(e))
 
     return xmatches
 

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -26,6 +26,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 import subprocess
 import sys
+import tensorflow as tf
 from tensorflow.keras.models import load_model
 import time
 import traceback
@@ -41,7 +42,11 @@ from utils import (
     radec2lb,
     time_stamp,
     timer,
+    ZTFAlert,
 )
+
+
+tf.config.optimizer.set_jit(True)
 
 
 """ load config and secrets """
@@ -247,7 +252,6 @@ def make_triplet(alert, to_tpu: bool = False):
 
 def alert_filter__ml(alert, ml_models: dict = None) -> dict:
     """Execute ML models on ZTF alerts
-
     :param alert:
     :param ml_models:
     :return:
@@ -255,15 +259,33 @@ def alert_filter__ml(alert, ml_models: dict = None) -> dict:
 
     scores = dict()
 
-    try:
-        """ braai """
-        triplet = make_triplet(alert)
-        triplets = np.expand_dims(triplet, axis=0)
-        braai = ml_models["braai"]["model"].predict(x=triplets)[0]
-        scores["braai"] = float(braai)
-        scores["braai_version"] = ml_models["braai"]["version"]
-    except Exception as e:
-        print(time_stamp(), str(e))
+    if ml_models is not None and len(ml_models) > 0:
+        try:
+            with timer("ZTFAlert(alert)"):
+                ztf_alert = ZTFAlert(alert)
+            with timer("Prepping features"):
+                features = np.expand_dims(ztf_alert.data["features"], axis=[0, -1])
+                triplet = np.expand_dims(ztf_alert.data["triplet"], axis=[0])
+
+            # braai
+            if "braai" in ml_models.keys():
+                with timer("braai"):
+                    braai = ml_models["braai"]["model"].predict(x=triplet)[0]
+                    scores["braai"] = float(braai)
+                    scores["braai_version"] = ml_models["braai"]["version"]
+            # acai
+            for model_name in ("acai_h", "acai_v", "acai_o", "acai_n", "acai_b"):
+                if model_name in ml_models.keys():
+                    with timer(model_name):
+                        score = ml_models[model_name]["model"].predict(
+                            [features, triplet]
+                        )[0]
+                        scores[model_name] = float(score)
+                        scores[f"{model_name}_version"] = ml_models[model_name][
+                            "version"
+                        ]
+        except Exception as e:
+            print(time_stamp(), str(e))
 
     return scores
 
@@ -490,8 +512,8 @@ def alert_filter__user_defined(
                 )
 
         except Exception as e:
-            print(
-                f'{time_stamp()}: filter {filter_template["fid"]} execution failed on alert {alert["candid"]}: {e}'
+            log(
+                f'Filter {filter_template["fid"]} execution failed on alert {alert["candid"]}: {e}'
             )
             continue
 
@@ -739,7 +761,7 @@ class AlertWorker:
                 model_version = config["ml_models"][model]["version"]
                 # todo: allow other formats such as SavedModel
                 model_filepath = os.path.join(
-                    config["path"]["ml_models"], f"{model}_{model_version}.h5"
+                    config["path"]["ml_models"], f"{model}.{model_version}.h5"
                 )
                 self.ml_models[model] = {
                     "model": load_model(model_filepath),

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -285,7 +285,7 @@ def alert_filter__ml(alert, ml_models: dict = None) -> dict:
                             "version"
                         ]
         except Exception as e:
-            print(time_stamp(), str(e))
+            log(str(e))
 
     return scores
 

--- a/kowalski/requirements_api.txt
+++ b/kowalski/requirements_api.txt
@@ -10,6 +10,7 @@ motor>=2.2.0
 multidict>=4.7.6
 numba>=0.51.1
 numpy>=1.19.1
+pandas>=1.1.1
 pyjwt>=1.7.1
 pymongo>=3.11.0
 pytest>=6.0.1


### PR DESCRIPTION
This PR adds support for a new family of ZTF alert classifiers, [`acai`](https://github.com/dmitryduev/acai) (Alert-Classifying AI).

Note: I was initially unhappy about the inference performance (~50ms per data sample per model), but with the refactored alert broker that will now use multiple `dask.distributed` workers, it may not be that bad. Willing to experiment with TFX serving. @stefanv @kmshin1397 would appreciate advice on that.

Upd 2020/11/24:
Experimented a lot with different serving options, pre-compiled/built from sources versions of `tf`, etc. -- not much effect since we are running inference on single data samples. With the new `dask.distributed`-based parallelization the inference performance should not be a problem.