### PR TITLE
Improve memory management in alert_broker_ztf

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -291,8 +291,8 @@ kowalski:
     scheduler_port: 8786
     n_workers: 4
     threads_per_worker: 1
-    lifetime: 1 hour
-    lifetime_stagger: 15 minutes
+    lifetime: 3 hours
+    lifetime_stagger: 30 minutes
     lifetime_restart: true
 
   misc:

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -291,6 +291,9 @@ kowalski:
     scheduler_port: 8786
     n_workers: 4
     threads_per_worker: 1
+    lifetime: 1 hour
+    lifetime_stagger: 15 minutes
+    lifetime_restart: true
 
   misc:
     # fixme: set to False if running stand-alone

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -690,7 +690,7 @@ class AlertConsumer:
 
                 for record in msg_decoded:
                     future = self.dask_client.submit(
-                        process_alert, deepcopy(record), self.topic, pure=True
+                        process_alert, record, self.topic, pure=True
                     )
                     dask.distributed.fire_and_forget(future)
                     future.release()

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -698,15 +698,15 @@ class AlertConsumer:
                     msg_decoded = self.decode_message(msg)
 
                 for record in msg_decoded:
-                    # f = self.dask_client.submit(
-                    #     process_alert, deepcopy(record), self.topic, pure=True
-                    # )
-                    # dask.distributed.fire_and_forget(f)
-                    self.futures.append(
-                        self.dask_client.submit(
-                            process_alert, deepcopy(record), self.topic, pure=True
-                        )
+                    f = self.dask_client.submit(
+                        process_alert, deepcopy(record), self.topic, pure=True
                     )
+                    dask.distributed.fire_and_forget(f)
+                    # self.futures.append(
+                    #     self.dask_client.submit(
+                    #         process_alert, deepcopy(record), self.topic, pure=True
+                    #     )
+                    # )
 
             except Exception as e:
                 log(e)

--- a/kowalski/dask_cluster.py
+++ b/kowalski/dask_cluster.py
@@ -14,6 +14,9 @@ if __name__ == "__main__":
         threads_per_worker=config["dask"]["threads_per_worker"],
         n_workers=config["dask"]["n_workers"],
         scheduler_port=config["dask"]["scheduler_port"],
+        lifetime=config["dask"]["lifetime"],  # "1 hour"
+        lifetime_stagger=config["dask"]["lifetime_stagger"],  # "15 minutes"
+        lifetime_restart=config["dask"]["lifetime_restart"],  # True
     )
     log(cluster)
 

--- a/kowalski/dask_cluster.py
+++ b/kowalski/dask_cluster.py
@@ -14,9 +14,9 @@ if __name__ == "__main__":
         threads_per_worker=config["dask"]["threads_per_worker"],
         n_workers=config["dask"]["n_workers"],
         scheduler_port=config["dask"]["scheduler_port"],
-        lifetime=config["dask"]["lifetime"],  # "1 hour"
-        lifetime_stagger=config["dask"]["lifetime_stagger"],  # "15 minutes"
-        lifetime_restart=config["dask"]["lifetime_restart"],  # True
+        lifetime=config["dask"]["lifetime"],
+        lifetime_stagger=config["dask"]["lifetime_stagger"],
+        lifetime_restart=config["dask"]["lifetime_restart"],
     )
     log(cluster)
 


### PR DESCRIPTION
It could be tricky working with long-running `dask` workers, especially when it comes to memory management. 

This PR improves the current solution by running `dask.distributed.fire_and_forget(future)` on the `futures` that assures running tasks at least once and not keeping the results in memory after the task completes. We also make sure to release the future and remove the reference to it.
Another trick implemented here is limited worker lifetime. Once elapsed, workers should be gracefully shut down and restarted.

As a side note:
Not "burning" the futures and harvesting computation results (in a separate thread, see first commits of this PR) pleases the default scheduler, which results in 2-3x higher throughput, but memory usage goes out of control - I tried a whole bunch of tricks, but no dice.