### PR TITLE
Submit only unprocessed alerts to dask workers

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -327,8 +327,8 @@ kowalski:
     scheduler_port: 8786
     n_workers: 4
     threads_per_worker: 1
-    lifetime: 3 hours
-    lifetime_stagger: 30 minutes
+    lifetime: 24 hours
+    lifetime_stagger: 1 hours
     lifetime_restart: true
 
   misc:

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -37,7 +37,7 @@ kowalski:
     zookeeper.test: "localhost:2181"
 
   database:
-    max_pool_size: 2000
+    max_pool_size: 200
     host: "kowalski_mongo_1"
     port: 27017
     db: "kowalski"

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -744,7 +744,7 @@ class AlertConsumer:
                         == 0
                     ):
                         with timer(
-                            f"Submitted alert {record['objectId']} {record['candid']} for processing",
+                            f"Submitting alert {record['objectId']} {record['candid']} for processing",
                             self.verbose > 1,
                         ):
                             future = self.dask_client.submit(


### PR DESCRIPTION
Move the check on the alert existence in the db upstream to cut on unnecessary traffic.