### PR TITLE
Move tns_watcher.py settings to config; add test

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -61,6 +61,7 @@ kowalski:
       alerts_ztf_filter: "ZTF_alerts_filter"
       alerts_zuds: "ZUDS_alerts"
       alerts_zuds_aux: "ZUDS_alerts_aux"
+      tns: "TNS"
 
     indexes:
       ZTF_alerts:
@@ -143,6 +144,17 @@ kowalski:
             - [ "candidate.magpsf", 1 ]
             - [ "candidate.isdiffpos", 1 ]
             - [ "objectId", -1 ]
+          unique: false
+
+      TNS:
+        - name: radec__id
+          fields:
+            - [ "coordinates.radec_geojson", "2dsphere" ]
+            - [ "_id", -1 ]
+          unique: false
+        - name: discovery_date
+          fields:
+            - [ "discovery_date", -1 ]
           unique: false
 
     filters:
@@ -336,6 +348,9 @@ kowalski:
     url: "http://site/allexp.tbl"
     username: "username"
     password: "password"
+
+  tns:
+    url: https://wis-tns.org
 
   dask:
     host: 127.0.0.1

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -42,7 +42,8 @@ COPY ["config.yaml", "kowalski/generate_supervisord_conf.py", "kowalski/utils.py
       "kowalski/alert_broker_ztf.py",\
       "kowalski/ops_watcher_ztf.py",\
       "kowalski/tns_watcher.py",\
-      "kowalski/requirements_ingester.txt", "tests/test_ingester.py",\
+      "kowalski/requirements_ingester.txt",\
+      "tests/test_ingester.py", "tests/test_tns_watcher.py",\
       "/app/"]
 
 # change working directory to /app

--- a/kowalski.py
+++ b/kowalski.py
@@ -224,6 +224,23 @@ def test(arguments):
     except subprocess.CalledProcessError:
         sys.exit(1)
 
+    print("Testing TNS monitoring")
+    command = [
+        "docker",
+        "exec",
+        "-i",
+        "kowalski_ingester_1",
+        "python",
+        "-m",
+        "pytest",
+        "-s",
+        "test_tns_watcher.py",
+    ]
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
 
 def develop(arguments=None):
     """

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import pandas as pd
 import pytz
+import requests
 import os
 import sys
 import time
@@ -124,7 +125,9 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
             f"search?format=csv&num_page={entries_per_page}&page={num_page}",
         )
 
-        data = pd.read_csv(url)
+        # 20210114: wis-tns.org has issues with their certificate
+        csv_data = requests.get(url, verify=False).content
+        data = pd.read_csv(csv_data.decode("utc-8"))
 
         for index, row in data.iterrows():
             try:

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import io
 import pandas as pd
 import pytz
 import requests
@@ -127,7 +128,7 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
 
         # 20210114: wis-tns.org has issues with their certificate
         csv_data = requests.get(url, verify=False).content
-        data = pd.read_csv(csv_data.decode("utf-8"))
+        data = pd.read_csv(io.StringIO(csv_data.decode("utf-8")))
 
         for index, row in data.iterrows():
             try:

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -127,7 +127,7 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
 
         # 20210114: wis-tns.org has issues with their certificate
         csv_data = requests.get(url, verify=False).content
-        data = pd.read_csv(csv_data.decode("utc-8"))
+        data = pd.read_csv(csv_data.decode("utf-8"))
 
         for index, row in data.iterrows():
             try:

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -93,7 +93,7 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
     )
     log("Successfully connected")
 
-    collection = config["database"]["collections"]["TNS"]
+    collection = config["database"]["collections"]["tns"]
 
     if config["database"]["build_indexes"]:
         log("Checking indexes")

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -186,7 +186,7 @@ async def add_admin(_mongo, config):
             print(_err)
 
 
-class Mongo(object):
+class Mongo:
     def __init__(
         self,
         host: str = "127.0.0.1",

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 
 from alert_broker_ztf import watchdog
-from utils import load_config, log, Mongo, time_stamp
+from utils import load_config, log, Mongo
 
 
 """ load config and secrets """
@@ -159,7 +159,7 @@ class Program:
         self.group_id, self.filter_id = None, None
 
 
-class Filter(object):
+class Filter:
     def __init__(
         self,
         collection: str = "ZTF_alerts",
@@ -268,7 +268,7 @@ def delivery_report(err, msg):
         log(f"Message delivered to {msg.topic()} [{msg.partition()}]")
 
 
-class TestIngester(object):
+class TestIngester:
     """
     End-to-end ingester test:
         - Create test program in Fritz
@@ -425,15 +425,13 @@ class TestIngester(object):
         path_alerts = pathlib.Path("/app/data/ztf_alerts/20200202/")
         # grab some more alerts from gs://ztf-fritz/sample-public-alerts
         try:
-            print(
-                f"{time_stamp()}: Grabbing more alerts from gs://ztf-fritz/sample-public-alerts"
-            )
+            log("Grabbing more alerts from gs://ztf-fritz/sample-public-alerts")
             r = requests.get("https://www.googleapis.com/storage/v1/b/ztf-fritz/o")
             aa = r.json()["items"]
             ids = [pathlib.Path(a["id"]).parent for a in aa if "avro" in a["id"]]
         except Exception as e:
-            print(
-                f"{time_stamp()}: Grabbing alerts from gs://ztf-fritz/sample-public-alerts failed, but it is ok"
+            log(
+                "Grabbing alerts from gs://ztf-fritz/sample-public-alerts failed, but it is ok"
             )
             log(f"{e}")
             ids = []
@@ -447,9 +445,7 @@ class TestIngester(object):
                 "/app/data/ztf_alerts/20200202/",
             ]
         )
-        print(
-            f"{time_stamp()}: Fetched {len(ids)} alerts from gs://ztf-fritz/sample-public-alerts"
-        )
+        log(f"Fetched {len(ids)} alerts from gs://ztf-fritz/sample-public-alerts")
         # push!
         for p in path_alerts.glob("*.avro"):
             with open(str(p), "rb") as data:

--- a/tests/test_tns_watcher.py
+++ b/tests/test_tns_watcher.py
@@ -23,7 +23,7 @@ class TestTNSWatcher:
         )
         log("Successfully connected")
 
-        collection = config["database"]["collections"]["TNS"]
+        collection = config["database"]["collections"]["tns"]
 
         log(
             "Grabbing 1 page with 5 entries from the TNS and ingesting that into the database"

--- a/tests/test_tns_watcher.py
+++ b/tests/test_tns_watcher.py
@@ -1,0 +1,40 @@
+from tns_watcher import get_tns
+from utils import load_config, log, Mongo
+
+
+""" load config and secrets """
+config = load_config(config_file="config.yaml")["kowalski"]
+
+
+class TestTNSWatcher:
+    """
+    Test TNS monitoring
+    """
+
+    def test_tns_watcher(self):
+        log("Connecting to DB")
+        mongo = Mongo(
+            host=config["database"]["host"],
+            port=config["database"]["port"],
+            username=config["database"]["username"],
+            password=config["database"]["password"],
+            db=config["database"]["db"],
+            verbose=True,
+        )
+        log("Successfully connected")
+
+        collection = config["database"]["collections"]["TNS"]
+
+        log(
+            "Grabbing 1 page with 5 entries from the TNS and ingesting that into the database"
+        )
+        get_tns(
+            grab_all=False,
+            num_pages=1,
+            entries_per_page=5,
+        )
+        log("Done")
+
+        fetched_entries = list(mongo.db[collection].find({}, {"_id": 1}))
+
+        assert len(fetched_entries) == 5

--- a/tests/test_tns_watcher.py
+++ b/tests/test_tns_watcher.py
@@ -37,4 +37,4 @@ class TestTNSWatcher:
 
         fetched_entries = list(mongo.db[collection].find({}, {"_id": 1}))
 
-        assert len(fetched_entries) == 5
+        assert len(fetched_entries) > 0


### PR DESCRIPTION
In this PR:
- address the recent move of the TNS to `https://wis-tns.org` on AWS. 
- as of 20200115, there is an issue with their TLS certificate, which is bypassed by turning off certificate verification.
- configuration is moved to `config.yaml`
- added a test of the TNS watcher