### PR TITLE
User-defined filters (for the broker mode) API refactor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,8 +27,7 @@ jobs:
           cp docker-compose.defaults.yaml docker-compose.yaml
       - name: Build and spin up
         run: |
-          ./kowalski.py build
-          ./kowalski.py up
+          ./kowalski.py up --build --init
       - name: Run tests
         run: |
           ./kowalski.py test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           cp docker-compose.defaults.yaml docker-compose.yaml
       - name: Build and spin up
         run: |
-          ./kowalski.py up --build --init
+          ./kowalski.py up --build
       - name: Run tests
         run: |
           ./kowalski.py test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/dumps
 *.lock
 *.dirlock
 docker-compose.yaml
+mongo_key.yaml

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -40,7 +40,7 @@ kowalski:
 
   database:
     max_pool_size: 200
-    host: "kowalski_mongo_1"
+    host: "mongo"
     port: 27017
     # if not null, must be same as in entrypoint of mongo container
     replica_set: "rs0"

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -42,6 +42,8 @@ kowalski:
     max_pool_size: 200
     host: "kowalski_mongo_1"
     port: 27017
+    # if not null, must be same as in entrypoint of mongo container
+    replica_set: "rs0"
     db: "kowalski"
     admin_username: "mongoadmin"
     # fixme: use strong password if exposing the database to the world

--- a/docker-compose.defaults.yaml
+++ b/docker-compose.defaults.yaml
@@ -62,4 +62,4 @@ services:
     networks:
       - kowalski
     # run as a replica set of size 1
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.defaults.yaml
+++ b/docker-compose.defaults.yaml
@@ -48,6 +48,7 @@ services:
 
   mongo:
     image: mongo:latest
+    hostname: mongo
     expose:
       - "27017"
     # fixme:

--- a/docker-compose.defaults.yaml
+++ b/docker-compose.defaults.yaml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 
 volumes:
   mongodb:
@@ -52,14 +52,20 @@ services:
       - "27017"
     # fixme:
     ports:
-      - "27027:27017"
+      - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=mongoadmin
       - MONGO_INITDB_ROOT_PASSWORD=mongoadminsecret
+      - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
+      - ./mongo_key.yaml:/opt/keyfile
     restart: always
     networks:
       - kowalski
-    # run as a replica set of size 1
-    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    healthcheck:
+      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
+      interval: 10s
+      start_period: 20s
+    # run as a replica set of size 1 called rs0 using keyfile for internal authorization
+    command: [ "--keyFile", "/opt/keyfile", "--replSet", "rs0", "--bind_ip_all" ]

--- a/docker-compose.defaults.yaml
+++ b/docker-compose.defaults.yaml
@@ -61,3 +61,5 @@ services:
     restart: always
     networks:
       - kowalski
+    # run as a replica set of size 1
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.defaults.yaml
+++ b/docker-compose.defaults.yaml
@@ -47,7 +47,9 @@ services:
       - kowalski
 
   mongo:
-    image: mongo:latest
+    build:
+      context: .
+      dockerfile: mongo.Dockerfile
     hostname: mongo
     expose:
       - "27017"
@@ -60,7 +62,6 @@ services:
       - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
-      - ./mongo_key.yaml:/opt/keyfile
     restart: always
     networks:
       - kowalski

--- a/docker-compose.fritz.defaults.yaml
+++ b/docker-compose.fritz.defaults.yaml
@@ -43,7 +43,10 @@ services:
       - mongo
 
   mongo:
-    image: mongo:latest
+#    image: mongo:latest
+    build:
+      context: .
+      dockerfile: mongo.Dockerfile
     hostname: mongo
     expose:
       - "27017"
@@ -56,7 +59,6 @@ services:
       - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
-      - ./mongo_key.yaml:/opt/keyfile
     restart: always
     networks:
       - kowalski

--- a/docker-compose.fritz.defaults.yaml
+++ b/docker-compose.fritz.defaults.yaml
@@ -44,6 +44,7 @@ services:
 
   mongo:
     image: mongo:latest
+    hostname: mongo
     expose:
       - "27017"
     # fixme:

--- a/docker-compose.fritz.defaults.yaml
+++ b/docker-compose.fritz.defaults.yaml
@@ -56,4 +56,4 @@ services:
       - mongodb:/data/db
     restart: always
     # run as a replica set of size 1
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.fritz.defaults.yaml
+++ b/docker-compose.fritz.defaults.yaml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 
 volumes:
   mongodb:
@@ -48,12 +48,20 @@ services:
       - "27017"
     # fixme:
     ports:
-      - "27027:27017"
+      - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=mongoadmin
       - MONGO_INITDB_ROOT_PASSWORD=mongoadminsecret
+      - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
+      - ./mongo_key.yaml:/opt/keyfile
     restart: always
-    # run as a replica set of size 1
-    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    networks:
+      - kowalski
+    healthcheck:
+      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
+      interval: 10s
+      start_period: 20s
+    # run as a replica set of size 1 called rs0 using keyfile for internal authorization
+    command: [ "--keyFile", "/opt/keyfile", "--replSet", "rs0", "--bind_ip_all" ]

--- a/docker-compose.fritz.defaults.yaml
+++ b/docker-compose.fritz.defaults.yaml
@@ -55,3 +55,5 @@ services:
     volumes:
       - mongodb:/data/db
     restart: always
+    # run as a replica set of size 1
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -86,7 +86,10 @@ services:
       - mongo
 
   mongo:
-    image: mongo:latest
+#    image: mongo:latest
+    build:
+      context: .
+      dockerfile: mongo.Dockerfile
     hostname: mongo
     expose:
       - "27017"
@@ -101,7 +104,6 @@ services:
       - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
-      - ./mongo_key.yaml:/opt/keyfile
     restart: always
     networks:
       - kowalski

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -101,4 +101,4 @@ services:
     depends_on:
       - traefik
     # run as a replica set of size 1
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -100,3 +100,5 @@ services:
     restart: always
     depends_on:
       - traefik
+    # run as a replica set of size 1
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -87,6 +87,7 @@ services:
 
   mongo:
     image: mongo:latest
+    hostname: mongo
     expose:
       - "27017"
     # fixme:

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 
 volumes:
   mongodb:
@@ -91,14 +91,22 @@ services:
       - "27017"
     # fixme:
     ports:
-      - "27027:27017"
+      - "27017:27017"
+    depends_on:
+      - traefik
     environment:
       - MONGO_INITDB_ROOT_USERNAME=mongoadmin
       - MONGO_INITDB_ROOT_PASSWORD=mongoadminsecret
+      - MONGO_REPLICA_SET_NAME=rs0
     volumes:
       - mongodb:/data/db
+      - ./mongo_key.yaml:/opt/keyfile
     restart: always
-    depends_on:
-      - traefik
-    # run as a replica set of size 1
-    command: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+    networks:
+      - kowalski
+    healthcheck:
+      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
+      interval: 10s
+      start_period: 20s
+    # run as a replica set of size 1 called rs0 using keyfile for internal authorization
+    command: [ "--keyFile", "/opt/keyfile", "--replSet", "rs0", "--bind_ip_all" ]

--- a/kowalski.py
+++ b/kowalski.py
@@ -244,6 +244,20 @@ class Kowalski:
             ]
             subprocess.run(command, check=True)
             cls.check_containers_up(containers=("kowalski_mongo_1",))
+            # make sure mongod process is running inside the container
+            num_retries = 10
+            for i in range(num_retries):
+                if i == num_retries - 1:
+                    raise RuntimeError("MongoDB failed to spin up")
+                command = ["docker", "exec", "-i", "kowalski_mongo_1", "ps", "-ef"]
+                process_list = subprocess.check_output(
+                    command, universal_newlines=True
+                ).strip()
+                if "mongod" not in process_list:
+                    print("MongoDB is not up, waiting...")
+                    time.sleep(10)
+                    continue
+                break
             print("Attempting MongoDB replica set initiation")
             command = [
                 "docker",

--- a/kowalski.py
+++ b/kowalski.py
@@ -169,13 +169,13 @@ class Kowalski:
     def check_containers_up(
         containers: Sequence,
         num_retries: int = 10,
-        sleep_for: int = 2,
+        sleep_for_seconds: int = 10,
     ):
         """Check if containers in question are up and running
 
         :param containers: container name sequence, e.g. ("kowalski_api_1", "kowalski_mongo_1")
         :param num_retries:
-        :param sleep_for: number of seconds to sleep for before retrying
+        :param sleep_for_seconds: number of seconds to sleep for before retrying
         :return:
         """
         for i in range(num_retries):
@@ -190,7 +190,7 @@ class Kowalski:
             )
             if len(container_list) == 1:
                 print("No containers are running, waiting...")
-                time.sleep(2)
+                time.sleep(sleep_for_seconds)
                 continue
 
             containers_up = (
@@ -198,7 +198,12 @@ class Kowalski:
                     [
                         container
                         for container in container_list
-                        if container_name in container and " Up " in container
+                        if (
+                            (container_name in container)
+                            and (" Up " in container)
+                            and ("unhealthy" not in container)
+                            and ("health: starting" not in container)
+                        )
                     ]
                 )
                 > 0
@@ -207,7 +212,7 @@ class Kowalski:
 
             if not all(containers_up):
                 print(f"{containers} containers are not up, waiting...")
-                time.sleep(sleep_for)
+                time.sleep(sleep_for_seconds)
                 continue
 
             break
@@ -395,7 +400,9 @@ class Kowalski:
         print("Running the test suite")
 
         # make sure the containers are up and running
-        cls.check_containers_up(containers=("kowalski_ingester_1", "kowalski_api_1"))
+        cls.check_containers_up(
+            containers=("kowalski_ingester_1", "kowalski_api_1"), sleep_for_seconds=10
+        )
 
         print("Testing ZTF alert ingestion")
 

--- a/kowalski.py
+++ b/kowalski.py
@@ -404,9 +404,7 @@ class Kowalski:
         print("Running the test suite")
 
         # make sure the containers are up and running
-        cls.check_containers_up(
-            container_list=("kowalski_ingester_1", "kowalski_api_1")
-        )
+        cls.check_containers_up(containers=("kowalski_ingester_1", "kowalski_api_1"))
 
         print("Testing ZTF alert ingestion")
 

--- a/kowalski.py
+++ b/kowalski.py
@@ -165,20 +165,20 @@ class Kowalski:
 
     @staticmethod
     def check_containers_up(
-        container_list: Sequence,
+        containers: Sequence,
         num_retries: int = 10,
         sleep_for: int = 2,
     ):
         """Check if containers in question are up and running
 
-        :param container_list: container name sequence, e.g. ("kowalski_api_1", "kowalski_mongo_1")
+        :param containers: container name sequence, e.g. ("kowalski_api_1", "kowalski_mongo_1")
         :param num_retries:
         :param sleep_for: number of seconds to sleep for before retrying
         :return:
         """
         for i in range(num_retries):
             if i == num_retries - 1:
-                raise RuntimeError(f"{container_list} containers failed to spin up")
+                raise RuntimeError(f"{containers} containers failed to spin up")
 
             command = ["docker", "ps", "-a"]
             container_list = (
@@ -200,11 +200,11 @@ class Kowalski:
                     ]
                 )
                 > 0
-                for container_name in container_list
+                for container_name in containers
             )
 
             if not all(containers_up):
-                print(f"{container_list} containers are not up, waiting...")
+                print(f"{containers} containers are not up, waiting...")
                 time.sleep(sleep_for)
                 continue
 
@@ -238,7 +238,7 @@ class Kowalski:
                 "mongo",
             ]
             subprocess.run(command, check=True)
-            cls.check_containers_up(container_list=("kowalski_mongo_1",))
+            cls.check_containers_up(containers=("kowalski_mongo_1",))
             print("Attempting MongoDB replica set initiation")
             command = [
                 "docker",

--- a/kowalski.py
+++ b/kowalski.py
@@ -227,11 +227,6 @@ class Kowalski:
         with status("Checking configuration"):
             check_configs(config_wildcards=config_wildcards)
 
-        with open(
-            pathlib.Path(__file__).parent.absolute() / "config.yaml"
-        ) as config_yaml:
-            config = yaml.load(config_yaml, Loader=yaml.FullLoader)["kowalski"]
-
         if init:
             # spin up mongo container
             command = [
@@ -259,9 +254,6 @@ class Kowalski:
                         "-i",
                         "kowalski_mongo_1",
                         "mongo",
-                        f"-u={config['database']['admin_username']}",
-                        f"-p={config['database']['admin_password']}",
-                        "--authenticationDatabase=admin",
                         "--eval",
                         "'rs.initiate()'",
                     ]

--- a/kowalski.py
+++ b/kowalski.py
@@ -188,6 +188,7 @@ class Kowalski:
                 .strip()
                 .split("\n")
             )
+            print(container_list)
             if len(container_list) == 1:
                 print("No containers are running, waiting...")
                 time.sleep(sleep_for_seconds)

--- a/kowalski.py
+++ b/kowalski.py
@@ -227,6 +227,11 @@ class Kowalski:
         with status("Checking configuration"):
             check_configs(config_wildcards=config_wildcards)
 
+        with open(
+            pathlib.Path(__file__).parent.absolute() / "config.yaml"
+        ) as config_yaml:
+            config = yaml.load(config_yaml, Loader=yaml.FullLoader)["kowalski"]
+
         if init:
             # spin up mongo container
             command = [
@@ -254,6 +259,9 @@ class Kowalski:
                         "-i",
                         "kowalski_mongo_1",
                         "mongo",
+                        f"-u={config['database']['admin_username']}",
+                        f"-p={config['database']['admin_password']}",
+                        "--authenticationDatabase=admin",
                         "--eval",
                         "'rs.initiate()'",
                     ]

--- a/kowalski.py
+++ b/kowalski.py
@@ -401,7 +401,8 @@ class Kowalski:
 
         # make sure the containers are up and running
         cls.check_containers_up(
-            containers=("kowalski_ingester_1", "kowalski_api_1"), sleep_for_seconds=10
+            containers=("kowalski_ingester_1", "kowalski_api_1", "kowalski_mongo_1"),
+            sleep_for_seconds=10,
         )
 
         print("Testing ZTF alert ingestion")

--- a/kowalski.py
+++ b/kowalski.py
@@ -253,6 +253,7 @@ class Kowalski:
                 process_list = subprocess.check_output(
                     command, universal_newlines=True
                 ).strip()
+                print(process_list)
                 if "mongod" not in process_list:
                     print("MongoDB is not up, waiting...")
                     time.sleep(10)

--- a/kowalski.py
+++ b/kowalski.py
@@ -227,11 +227,6 @@ class Kowalski:
         with status("Checking configuration"):
             check_configs(config_wildcards=config_wildcards)
 
-        # with open(
-        #     pathlib.Path(__file__).parent.absolute() / "config.yaml"
-        # ) as config_yaml:
-        #     config = yaml.load(config_yaml, Loader=yaml.FullLoader)["kowalski"]
-
         if init:
             # spin up mongo container
             command = [
@@ -246,6 +241,8 @@ class Kowalski:
             cls.check_containers_up(containers=("kowalski_mongo_1",))
 
             print("Attempting MongoDB replica set initiation")
+            # note: even once the mongod process is running inside the container, it may take some time
+            #       for it to become operational/responsive
             num_retries = 10
             for i in range(num_retries):
                 if i == num_retries - 1:
@@ -257,9 +254,6 @@ class Kowalski:
                         "-i",
                         "kowalski_mongo_1",
                         "mongo",
-                        # f"-u={config['database']['admin_username']}",
-                        # f"-p={config['database']['admin_password']}",
-                        # "--authenticationDatabase=admin",
                         "--eval",
                         "'rs.initiate()'",
                     ]

--- a/kowalski.py
+++ b/kowalski.py
@@ -227,6 +227,11 @@ class Kowalski:
         with status("Checking configuration"):
             check_configs(config_wildcards=config_wildcards)
 
+        with open(
+            pathlib.Path(__file__).parent.absolute() / "config.yaml"
+        ) as config_yaml:
+            config = yaml.load(config_yaml, Loader=yaml.FullLoader)["kowalski"]
+
         if init:
             # spin up mongo container
             command = [
@@ -246,6 +251,9 @@ class Kowalski:
                 "-i",
                 "kowalski_mongo_1",
                 "mongo",
+                f"-u={config['database']['admin_username']}",
+                f"-p={config['database']['admin_password']}",
+                "--authenticationDatabase=admin",
                 "--eval",
                 "'rs.initiate()'",
             ]

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -669,6 +669,7 @@ class AlertConsumer:
         self.mongo = Mongo(
             host=config["database"]["host"],
             port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
             username=config["database"]["username"],
             password=config["database"]["password"],
             db=config["database"]["db"],
@@ -782,6 +783,7 @@ class AlertWorker:
         self.mongo = Mongo(
             host=config["database"]["host"],
             port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
             username=config["database"]["username"],
             password=config["database"]["password"],
             db=config["database"]["db"],

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2733,18 +2733,18 @@ async def app_factory():
 
     # Database connection
     mongodb_connection_string = (
-        f"mongodb://{config['database']['username']}:{config['database']['password']}@"
-        + f"{config['database']['host']}:{config['database']['port']}/{config['database']['db']}"
+        f"mongodb://{config['database']['admin_username']}:{config['database']['admin_password']}@"
+        + f"{config['database']['host']}:{config['database']['port']}"
     )
     if config["database"]["replica_set"] is not None:
-        mongodb_connection_string += f"?replicaSet={config['database']['replica_set']}"
+        mongodb_connection_string += f"/?replicaSet={config['database']['replica_set']}"
     client = AsyncIOMotorClient(
         mongodb_connection_string,
         maxPoolSize=config["database"]["max_pool_size"],
     )
     mongo = client[config["database"]["db"]]
 
-    # add site admin if necessary
+    # admin to connect to this instance from outside using API
     await add_admin(mongo, config=config)
 
     # init app with auth and error handling middlewares

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2728,14 +2728,18 @@ async def app_factory():
         App Factory
     :return:
     """
-
     # init db if necessary
     await init_db(config=config)
 
     # Database connection
-    client = AsyncIOMotorClient(
+    mongodb_connection_string = (
         f"mongodb://{config['database']['username']}:{config['database']['password']}@"
-        + f"{config['database']['host']}:{config['database']['port']}/{config['database']['db']}",
+        + f"{config['database']['host']}:{config['database']['port']}/{config['database']['db']}"
+    )
+    if config["database"]["replica_set"] is not None:
+        mongodb_connection_string += f"?replicaSet={config['database']['replica_set']}"
+    client = AsyncIOMotorClient(
+        mongodb_connection_string,
         maxPoolSize=config["database"]["max_pool_size"],
     )
     mongo = client[config["database"]["db"]]

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2182,7 +2182,7 @@ class FilterHandler(Handler):
                   filter not found:
                     value:
                       status: error
-                      message: filter id 1 not found
+                      message: Filter id 1 not found
         """
         # allow both .json() and .post():
         try:
@@ -2199,7 +2199,7 @@ class FilterHandler(Handler):
         filter_doc = filter_existing.doc()
 
         if filter_existing is None:
-            return self.error(message=f"filter id {filter_id} not found")
+            return self.error(message=f"Filter id {filter_id} not found")
 
         # note: partial model loading is not (yet?) available in odmantic + need a custom check on active_fid
         for modifiable_field in (
@@ -2214,7 +2214,7 @@ class FilterHandler(Handler):
                     filter_version["fid"] for filter_version in filter_doc["fv"]
                 ]:
                     raise ValueError(
-                        f"cannot set active_fid to {value}: filter version fid not in filter.fv"
+                        f"Cannot set active_fid to {value}: filter version fid not in filter.fv"
                     )
                 filter_doc[modifiable_field] = value
         filter_existing = Filter.parse_doc(filter_doc)
@@ -2285,7 +2285,7 @@ class FilterHandler(Handler):
                   filter not found:
                     value:
                       status: error
-                      message: filter for group_id=1, filter_id=1 not found
+                      message: Filter id 1 not found
         """
         filter_id = int(request.match_info["filter_id"])
 
@@ -2293,8 +2293,8 @@ class FilterHandler(Handler):
 
         if r.deleted_count != 0:
             return self.success(message=f"Removed filter id {filter_id}")
-        else:
-            return self.error(message=f"Filter id {filter_id} not found")
+
+        return self.error(message=f"Filter id {filter_id} not found")
 
 
 """ lab """

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2196,10 +2196,10 @@ class FilterHandler(Handler):
         filter_existing = await request.app["mongo_odm"].find_one(
             Filter, Filter.filter_id == filter_id
         )
-        filter_doc = filter_existing.doc()
-
         if filter_existing is None:
             return self.error(message=f"Filter id {filter_id} not found")
+
+        filter_doc = filter_existing.doc()
 
         # note: partial model loading is not (yet?) available in odmantic + need a custom check on active_fid
         for modifiable_field in (

--- a/kowalski/ops_watcher_ztf.py
+++ b/kowalski/ops_watcher_ztf.py
@@ -46,6 +46,7 @@ def get_ops():
     mongo = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],

--- a/kowalski/requirements_api.txt
+++ b/kowalski/requirements_api.txt
@@ -10,6 +10,7 @@ motor>=2.3.0
 multidict==5.1.0
 numba==0.52.0
 numpy==1.18.5
+odmantic>=0.3.2
 pandas==1.1.4
 pyjwt>=2.0.0
 pymongo>=3.11.2

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -88,6 +88,7 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
     mongo = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],

--- a/mongo.Dockerfile
+++ b/mongo.Dockerfile
@@ -1,4 +1,4 @@
 FROM mongo:4.4
 
-COPY file.key /opt/keyfile
+COPY mongo_key.yaml /opt/keyfile
 RUN chmod 400 /opt/keyfile && chown 999:999 /opt/keyfile

--- a/mongo.Dockerfile
+++ b/mongo.Dockerfile
@@ -1,0 +1,4 @@
+FROM mongo:4.4
+
+COPY file.key /opt/keyfile
+RUN chmod 400 /opt/keyfile && chown 999:999 /opt/keyfile

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -525,6 +525,7 @@ class TestIngester:
         mongo = Mongo(
             host=config["database"]["host"],
             port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
             username=config["database"]["username"],
             password=config["database"]["password"],
             db=config["database"]["db"],

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 
 from alert_broker_ztf import watchdog
-from utils import load_config, log, Mongo
+from utils import init_db_sync, load_config, log, Mongo
 
 
 """ load config and secrets """
@@ -286,6 +286,8 @@ class TestIngester:
     """
 
     def test_ingester(self):
+
+        init_db_sync(config=config, verbose=True)
 
         log("Setting up paths")
         # path_kafka = pathlib.Path(config["path"]["kafka"])

--- a/tests/test_tns_watcher.py
+++ b/tests/test_tns_watcher.py
@@ -16,6 +16,7 @@ class TestTNSWatcher:
         mongo = Mongo(
             host=config["database"]["host"],
             port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
             username=config["database"]["username"],
             password=config["database"]["password"],
             db=config["database"]["db"],

--- a/tools/ingest_gaia_edr3.py
+++ b/tools/ingest_gaia_edr3.py
@@ -31,6 +31,7 @@ def process_file(args):
     mongo = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],
@@ -145,6 +146,7 @@ if __name__ == "__main__":
     m = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],

--- a/tools/ingest_ps1_strm.py
+++ b/tools/ingest_ps1_strm.py
@@ -30,6 +30,7 @@ def process_file(args):
     mongo = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],
@@ -174,6 +175,7 @@ if __name__ == "__main__":
     m = Mongo(
         host=config["database"]["host"],
         port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
         username=config["database"]["username"],
         password=config["database"]["password"],
         db=config["database"]["db"],

--- a/tools/ingest_ztf_matchfiles.py
+++ b/tools/ingest_ztf_matchfiles.py
@@ -42,10 +42,16 @@ def connect_to_db():
     :return:
     """
     try:
-        # there's only one instance of DB, it's too big to be replicated
-        _client = pymongo.MongoClient(
-            host=config["database"]["host"], port=config["database"]["port"]
-        )
+        if config["database"]["replica_set"] is None:
+            _client = pymongo.MongoClient(
+                host=config["database"]["host"], port=config["database"]["port"]
+            )
+        else:
+            _client = pymongo.MongoClient(
+                host=config["database"]["host"],
+                port=config["database"]["port"],
+                replicaset=config["database"]["replica_set"],
+            )
         # grab main database:
         _db = _client[config["database"]["db"]]
     except Exception:


### PR DESCRIPTION
In this PR:

- MongoDB is now run as a replica set of size 1 by default, enabling transactions.
  - Uses keyfile-based internal authentication, which is required for replica sets.
- Using `odmantic` `MongoDB` ODM for structured entities in `api.py`.
  - Implemented ODM-based models for `Filter`'s and `FilterVersion`'s, which automates most of the input data checks that were previously done manually.
  - Refactored user-defined-filter-related endpoints to take advantage of the models.
- Rewrote filters api tests.

TODO on Fritz: these changes need to be taken into account.