### PR TITLE
Refactor the queries API and implement new query type "near"

### DIFF
--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -180,8 +180,7 @@ async def auth_post(request: web.Request) -> web.Response:
     try:
         try:
             post_data = await request.json()
-        except Exception as _e:
-            log(_e)
+        except AttributeError:
             post_data = await request.post()
 
         # must contain 'username' and 'password'
@@ -721,11 +720,11 @@ class Query(Model, ABC):
         if units not in ANGULAR_UNITS:
             raise Exception(f"Angular units not in {ANGULAR_UNITS}")
         if units == "arcsec":
-            angle_rad *= np.pi / 180.0 / 3600.0
+            angle_rad *= np.pi / 180 / 3600
         elif units == "arcmin":
-            angle_rad *= np.pi / 180.0 / 60.0
+            angle_rad *= np.pi / 180 / 60
         elif units == "deg":
-            angle_rad *= np.pi / 180.0
+            angle_rad *= np.pi / 180
 
         return angle_rad
 
@@ -931,7 +930,7 @@ class Query(Model, ABC):
             )
 
             max_distance = cls.angle_to_rad(
-                angle=query.get("max_distance", np.pi / 180.0 / 60.0),  # default to 1'
+                angle=query.get("max_distance", np.pi / 180 / 60),  # default to 1'
                 units=query.get("distance_units", "rad"),
             )
 

--- a/kowalski/components_api.yaml
+++ b/kowalski/components_api.yaml
@@ -284,3 +284,89 @@ components:
             default: 300000
             description: "maximum query execution time in ms. defaults to 5 minutes"
             minimum: 1
+
+    near:
+      type: object
+      required:
+        - catalogs
+        - radec
+      properties:
+        catalogs:
+          type: object
+          additionalProperties:
+            type: object
+            required:
+              - "<catalog_name>"
+            properties:
+              "<catalog_name>":
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    filter:
+                      type: object
+                      description: "filter expression in MQL"
+                    projection:
+                      type: object
+                      description: "projection expression (document fields to return/ditch) in MQL"
+                description: "define filter and projection per catalog."
+        min_distance:
+          oneOf:
+            - type: number
+            - type: string
+          description: "min distance"
+        max_distance:
+          oneOf:
+            - type: number
+            - type: string
+          description: "max distance"
+        distance_units:
+          type: string
+          enum: [ arcsec, arcmin, deg, rad ]
+          description: "min and max distance units"
+        radec:
+          oneOf:
+            - type: array
+              items:
+                type: array
+                items:
+                  oneOf:
+                    - type: string
+                      description: "('HH:MM:SS', 'DD:MM:SS') or ('HHhMMmSSs', 'DDdMMmSSs')"
+                    - type: number
+                      description: "(deg, deg)"
+                  minItems: 2
+                  maxItems: 2
+                minItems: 1
+            - type: object
+              description: "{'object_name': [<ra>, <dec>], ...} <ra/dec> could be either strings or numbers [deg]"
+            - type: string
+          description: "ICRF position(s): R.A. and Decl."
+      near_kwargs:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            max_time_ms:
+              type: integer
+              default: 300000
+              description: "maximum query execution time in ms. defaults to 5 minutes"
+              minimum: 1
+            filter_first:
+              type: boolean
+              default: false
+              description: "apply filter before positional query?"
+            skip:
+              type: integer
+              description: "number of matched documents to skip"
+              minimum: 0
+            hint:
+              type: string
+              description: "index name to use"
+            limit:
+              type: integer
+              description: "maximum number of matched documents to return"
+              minimum: 1
+            sort:
+              type: array
+              description: "sorting order"

--- a/kowalski/components_api.yaml
+++ b/kowalski/components_api.yaml
@@ -342,31 +342,31 @@ components:
               description: "{'object_name': [<ra>, <dec>], ...} <ra/dec> could be either strings or numbers [deg]"
             - type: string
           description: "ICRF position(s): R.A. and Decl."
-      near_kwargs:
+    near_kwargs:
+      type: object
+      additionalProperties:
         type: object
-        additionalProperties:
-          type: object
-          properties:
-            max_time_ms:
-              type: integer
-              default: 300000
-              description: "maximum query execution time in ms. defaults to 5 minutes"
-              minimum: 1
-            filter_first:
-              type: boolean
-              default: false
-              description: "apply filter before positional query?"
-            skip:
-              type: integer
-              description: "number of matched documents to skip"
-              minimum: 0
-            hint:
-              type: string
-              description: "index name to use"
-            limit:
-              type: integer
-              description: "maximum number of matched documents to return"
-              minimum: 1
-            sort:
-              type: array
-              description: "sorting order"
+        properties:
+          max_time_ms:
+            type: integer
+            default: 300000
+            description: "maximum query execution time in ms. defaults to 5 minutes"
+            minimum: 1
+          filter_first:
+            type: boolean
+            default: false
+            description: "apply filter before positional query?"
+          skip:
+            type: integer
+            description: "number of matched documents to skip"
+            minimum: 0
+          hint:
+            type: string
+            description: "index name to use"
+          limit:
+            type: integer
+            description: "maximum number of matched documents to return"
+            minimum: 1
+          sort:
+            type: array
+            description: "sorting order"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -485,7 +485,7 @@ class TestAPIs(object):
 
     async def test_query_cone_search(self, aiohttp_client):
         """
-            Test {"query_type": "cone_search", ...}: /api/queries
+            Test {"query_type": "cone_search", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -521,16 +521,15 @@ class TestAPIs(object):
         resp = await client.post("/api/queries", json=qu, headers=headers, timeout=5)
         assert resp.status == 200
         result = await resp.json()
-        # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
         # should always return a dict, even if it's empty
         assert isinstance(result["data"], dict)
 
     async def test_query_find_one(self, aiohttp_client):
         """
-            Test {"query_type": "find_one", ...}: /api/queries
+            Test {"query_type": "find_one", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -559,12 +558,12 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
 
     async def test_query_find(self, aiohttp_client):
         """
-            Test {"query_type": "find", ...}: /api/queries
+            Test {"query_type": "find", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -594,14 +593,14 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
         # should always return a list, even if it's empty
         assert isinstance(result["data"], list)
 
     async def test_query_aggregate(self, aiohttp_client):
         """
-            Test {"query_type": "aggregate", ...}: /api/queries
+            Test {"query_type": "aggregate", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -633,12 +632,12 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
 
     async def test_query_info(self, aiohttp_client):
         """
-            Test {"query_type": "info", ...}: /api/queries
+            Test {"query_type": "info", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -658,12 +657,12 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
 
     async def test_query_count_documents(self, aiohttp_client):
         """
-            Test {"query_type": "count_documents", ...}: /api/queries
+            Test {"query_type": "count_documents", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -688,13 +687,13 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
         assert result["data"] == 0
 
     async def test_query_estimated_document_count(self, aiohttp_client):
         """
-            Test {"query_type": "estimated_document_count", ...}: /api/queries
+            Test {"query_type": "estimated_document_count", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -719,7 +718,7 @@ class TestAPIs(object):
         result = await resp.json()
         # print(result)
         assert result["status"] == "success"
-        assert result["message"] == "query successfully executed"
+        assert result["message"] == "Successfully executed query"
         assert "data" in result
         # assert result['data'] == 0
 
@@ -727,7 +726,7 @@ class TestAPIs(object):
 
     async def test_query_unauthorized(self, aiohttp_client):
         """
-            Test an unauthorized query: /api/queries
+            Test an unauthorized query: POST /api/queries
         :param aiohttp_client:
         :return:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -723,7 +723,7 @@ class TestAPIs(object):
 
     async def test_query_near(self, aiohttp_client):
         """
-            Test {"query_type": "cone_search", ...}: POST /api/queries
+            Test {"query_type": "near", ...}: POST /api/queries
         :param aiohttp_client:
         :return:
         """
@@ -754,7 +754,6 @@ class TestAPIs(object):
             },
             "kwargs": {"filter_first": False},
         }
-        # print(qu)
         resp = await client.post("/api/queries", json=qu, headers=headers, timeout=5)
         assert resp.status == 200
         result = await resp.json()

--- a/tests/test_ingester.py
+++ b/tests/test_ingester.py
@@ -488,7 +488,7 @@ class TestIngester:
         log("Digested and ingested: all done!")
 
         # shut down Kafka server and ZooKeeper
-        time.sleep(10)
+        time.sleep(20)
 
         log("Shutting down Kafka Server at localhost:9092")
         # start the Kafka server:


### PR DESCRIPTION
In this PR:

- Refactor the queries API to do data validation and preprocessing using `odmantic`: it is now cleaner and more concise (-400 lines of code).
  - Assemble the relevant handlers into a class.
  - Ditch the ability to save queries to db and execute them in the background: no one has used this capability for about a year.
- Implement a new query type `near` that returns the nearest object(s), sorted by angular distance, in a catalog from a given position. Here's an example query that returns 3 nearest objects in the `milliquas_v6` catalog within 10 degrees from R.A./Decl. = (212.7867456, 59.8409095):
```json
{
    "query_type": "near",
    "query": {
        "max_distance": 10,
        "distance_units": "deg",
        "radec": {
            "ZTF20aahgyet": [
                212.7867456,
                59.8409095
            ]
        },
        "catalogs": {
            "milliquas_v6": {
                "filter": {},
                "projection": {
                    "_id": 1,
                    "RA": 1,
                    "DEC": 1
                }
            }
        }
    },
    "kwargs": {
        "limit": 3
    }
}
```