### PR TITLE
Use factories for default field values in filter models

### DIFF
--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -1476,8 +1476,9 @@ class Filter(Model, ABC):
     class Config:
         # collection name in MongoDB
         collection = "filters"
-        json_loads = loads
         json_dumps = dumps
+        json_loads = loads
+        parse_doc_with_default_factories = True
 
 
 class FilterHandler(Handler):

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -1430,9 +1430,9 @@ class QueryHandler(Handler):
 class FilterVersion(EmbeddedModel, ABC):
     """Data model for Filter versions"""
 
-    fid: str = uid(length=6)
+    fid: str = Field(default_factory=uid)
     pipeline: str
-    created_at: datetime.datetime = datetime.datetime.utcnow()
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
 
     @root_validator
     def check_min_stages(cls, values):
@@ -1453,8 +1453,9 @@ class FilterVersion(EmbeddedModel, ABC):
         return values
 
     class Config:
-        json_loads = loads
         json_dumps = dumps
+        json_loads = loads
+        parse_doc_with_default_factories = True
 
 
 class Filter(Model, ABC):
@@ -1469,8 +1470,8 @@ class Filter(Model, ABC):
     update_annotations: bool = False
     active_fid: Optional[str] = Field(min_length=6, max_length=6)
     fv: List[FilterVersion] = list()
-    created_at: datetime.datetime = datetime.datetime.utcnow()
-    last_modified: datetime.datetime = datetime.datetime.utcnow()
+    created_at: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
+    last_modified: datetime.datetime = Field(default_factory=datetime.datetime.utcnow)
 
     class Config:
         # collection name in MongoDB

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,6 +203,9 @@ class TestAPIs(object):
         assert "fid" in result["data"]
         fid2 = result["data"]["fid"]
 
+        # generated new id?
+        assert fid2 != fid1
+
         # retrieve again
         resp = await client.get(f"/api/filters/{filter_id}", headers=headers, timeout=5)
         assert resp.status == 200


### PR DESCRIPTION
This PR fixes a bug in Filter and FilterVersion ODM models: should be using default factories for default field values and not default values.