### PR TITLE
Add supervisord process to post daily performance reports to Slack

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -69,129 +69,158 @@ kowalski:
       ZTF_alerts:
         - name: radec_candid
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "candid", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["candid", -1]
           unique: false
         - name: radec_objectId
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "objectId", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["objectId", -1]
           unique: false
         - name: jd_radec_candid
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", 1]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["candid", -1]
           unique: false
         - name: jd_radec_objectId
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "objectId", -1 ]
+            - ["candidate.jd", 1]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["objectId", -1]
           unique: false
         - name: objectId
           fields:
-            - [ "objectId", -1 ]
+            - ["objectId", -1]
           unique: false
         - name: candid
           fields:
-            - [ "candid", -1 ]
+            - ["candid", -1]
           unique: true
         - name: pid
           fields:
-            - [ "candidate.pid", 1 ]
+            - ["candidate.pid", 1]
           unique: false
         - name: objectId_pid
           fields:
-            - [ "objectId", -1 ]
-            - [ "candidate.pid", 1 ]
+            - ["objectId", -1]
+            - ["candidate.pid", 1]
           unique: false
         - name: pdiffimfilename
           fields:
-            - [ "candidate.pdiffimfilename", 1 ]
+            - ["candidate.pdiffimfilename", 1]
           unique: false
         - name: jd_programid_programpi
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "candidate.programid", 1 ]
-            - [ "candidate.programpi", 1 ]
+            - ["candidate.jd", 1]
+            - ["candidate.programid", 1]
+            - ["candidate.programpi", 1]
           unique: false
         - name: jd_braai_candid
           fields:
-            - [ "candidate.jd", -1 ]
-            - [ "classifications.braai", -1 ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", -1]
+            - ["classifications.braai", -1]
+            - ["candid", -1]
           unique: false
         - name: jd_drb_candid
           fields:
-            - [ "candidate.jd", -1 ]
-            - [ "candidate.drb", -1 ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", -1]
+            - ["candidate.drb", -1]
+            - ["candid", -1]
           unique: false
         - name: jd_braai_magpsf_isdiffpos_ndethist
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "classifications.braai", 1 ]
-            - [ "candidate.magpsf", 1 ]
-            - [ "candidate.isdiffpos", 1 ]
-            - [ "candidate.ndethist", 1 ]
+            - ["candidate.jd", 1]
+            - ["classifications.braai", 1]
+            - ["candidate.magpsf", 1]
+            - ["candidate.isdiffpos", 1]
+            - ["candidate.ndethist", 1]
           unique: false
         - name: jd_field_drb_ndethhist_magpsf_isdiffpos_objectId
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "candidate.field", 1 ]
-            - [ "candidate.rb", 1 ]
-            - [ "candidate.drb", 1 ]
-            - [ "candidate.ndethist", 1 ]
-            - [ "candidate.magpsf", 1 ]
-            - [ "candidate.isdiffpos", 1 ]
-            - [ "objectId", -1 ]
+            - ["candidate.jd", 1]
+            - ["candidate.field", 1]
+            - ["candidate.rb", 1]
+            - ["candidate.drb", 1]
+            - ["candidate.ndethist", 1]
+            - ["candidate.magpsf", 1]
+            - ["candidate.isdiffpos", 1]
+            - ["objectId", -1]
           unique: false
 
       TNS:
         - name: radec__id
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "_id", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["_id", -1]
           unique: false
         - name: discovery_date
           fields:
-            - [ "discovery_date", -1 ]
+            - ["discovery_date", -1]
           unique: false
 
     filters:
       ZTF_alerts:
         # default upstream aggregation pipeline stages for filtering ZTF alerts:
-        - {"$match": {"candid": null, "candidate.programid": {"$in": null}}}
-        - {"$project": {"cutoutScience": 0, "cutoutTemplate": 0, "cutoutDifference": 0}}
-        - {"$lookup": {"from": "ZTF_alerts_aux", "localField": "objectId", "foreignField": "_id", "as": "aux"}}
-        - {"$project": {
-          "cross_matches": {
-            "$arrayElemAt": [
-              "$aux.cross_matches", 0
-            ]
-          },
-          "prv_candidates": {
-            "$filter": {
-              "input": {"$arrayElemAt": ["$aux.prv_candidates", 0]},
-              "as": "item",
-              "cond": {
-                "$and": [
-                  {"$in": ["$$item.programid", null]},
-                  {"$lt": [{"$subtract": ["$candidate.jd", "$$item.jd"]}, 100]}
-                ]
-              }
-            }
-          },
-          "schemavsn": 1,
-          "publisher": 1,
-          "objectId": 1,
-          "candid": 1,
-          "candidate": 1,
-          "classifications": 1,
-          "coordinates": 1
+        - {
+            "$match":
+              { "candid": null, "candidate.programid": { "$in": null } },
           }
-        }
+        - {
+            "$project":
+              {
+                "cutoutScience": 0,
+                "cutoutTemplate": 0,
+                "cutoutDifference": 0,
+              },
+          }
+        - {
+            "$lookup":
+              {
+                "from": "ZTF_alerts_aux",
+                "localField": "objectId",
+                "foreignField": "_id",
+                "as": "aux",
+              },
+          }
+        - {
+            "$project":
+              {
+                "cross_matches": { "$arrayElemAt": ["$aux.cross_matches", 0] },
+                "prv_candidates":
+                  {
+                    "$filter":
+                      {
+                        "input": { "$arrayElemAt": ["$aux.prv_candidates", 0] },
+                        "as": "item",
+                        "cond":
+                          {
+                            "$and":
+                              [
+                                { "$in": ["$$item.programid", null] },
+                                {
+                                  "$lt":
+                                    [
+                                      {
+                                        "$subtract":
+                                          ["$candidate.jd", "$$item.jd"],
+                                      },
+                                      100,
+                                    ],
+                                },
+                              ],
+                          },
+                      },
+                  },
+                "schemavsn": 1,
+                "publisher": 1,
+                "objectId": 1,
+                "candid": 1,
+                "candidate": 1,
+                "classifications": 1,
+                "coordinates": 1,
+              },
+          }
 
     xmatch:
       cone_search_radius: 2
@@ -209,17 +238,17 @@ kowalski:
         AllWISE:
           filter: {}
           projection:
-             _id: 1
-             coordinates.radec_str: 1
-             w1mpro: 1
-             w1sigmpro: 1
-             w2mpro: 1
-             w2sigmpro: 1
-             w3mpro: 1
-             w3sigmpro: 1
-             w4mpro: 1
-             w4sigmpro: 1
-             ph_qual: 1
+            _id: 1
+            coordinates.radec_str: 1
+            w1mpro: 1
+            w1sigmpro: 1
+            w2mpro: 1
+            w2sigmpro: 1
+            w3mpro: 1
+            w3sigmpro: 1
+            w4mpro: 1
+            w4sigmpro: 1
+            ph_qual: 1
 
         Gaia_DR2:
           filter: {}
@@ -314,7 +343,7 @@ kowalski:
             snrz: 1
             objtype: 1
             class: 1
-            subclass:  1
+            subclass: 1
 
         PS1_DR1:
           filter: {}
@@ -334,7 +363,7 @@ kowalski:
 
   ml_models:
     braai:
-      version:  "d6_m9"
+      version: "d6_m9"
     acai_h:
       version: "d1_dnn_20201130"
     acai_v:
@@ -384,7 +413,12 @@ kowalski:
     max_time_ms: 300000
     max_retries: 100
     logging_level: "debug"
-    openapi_validate:  False
+    openapi_validate: False
+
+  slack:
+    # Used by the performance_reporter.py task to post Slack messages
+    slack_bot_token:
+    slack_channel_id:
 
   # this is used to make supervisord.conf files at build time
   supervisord:
@@ -504,3 +538,13 @@ kowalski:
         stdout_logfile_maxbytes: 30MB
         redirect_stderr: True
         environment: "PRODUCTION=1"
+
+      "program:performance_reporter":
+        command: /usr/local/bin/python performance_reporter.py --send_to_slack --days_ago 1
+        directory: /app
+        user: root
+        autostart: true
+        autorestart: true
+        stdout_logfile: /data/logs/performance_reporter_stdout.log
+        stdout_logfile_maxbytes: 10MB
+        redirect_stderr: True

--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -42,6 +42,7 @@ COPY ["config.yaml", "kowalski/generate_supervisord_conf.py", "kowalski/utils.py
       "kowalski/alert_broker_ztf.py",\
       "kowalski/ops_watcher_ztf.py",\
       "kowalski/tns_watcher.py",\
+      "kowalski/performance_reporter.py",\
       "kowalski/requirements_ingester.txt",\
       "tests/test_ingester.py", "tests/test_tns_watcher.py",\
       "tools/ingest_ztf_matchfiles.py", "tools/istarmap.py",\

--- a/kowalski/performance_reporter.py
+++ b/kowalski/performance_reporter.py
@@ -112,8 +112,16 @@ def generate_report(output_path, start_date, end_date):
                 label=action,
                 histtype="step",
             )
-
-        plt.legend(loc="upper right")
+        if len(actions) > 0:
+            plt.legend(loc="upper right")
+        else:
+            firstPage.text(
+                0.5,
+                0.7,
+                "No relevant recent logs.",
+                transform=firstPage.transFigure,
+                ha="center",
+            )
         pdf.savefig()
         plt.close()
 

--- a/kowalski/performance_reporter.py
+++ b/kowalski/performance_reporter.py
@@ -1,0 +1,210 @@
+import datetime
+import pathlib
+import re
+from collections import defaultdict
+import argparse
+import time
+import sys
+import traceback
+
+from matplotlib.backends.backend_pdf import PdfPages
+import matplotlib.pyplot as plt
+import numpy as np
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+from utils import load_config, log
+
+""" load config and secrets """
+config = load_config(config_file="config.yaml")["kowalski"]
+
+p_base = config["path"]["logs"]
+
+log_dir = pathlib.Path(p_base)
+log_files = list(log_dir.glob("dask_cluster*"))
+actions = defaultdict(list)
+
+action_patterns = {
+    "Mongification": "mongification",
+    "ML": "MLing",
+    "Ingestion": "Ingesting",
+    "Cross-match": "Cross-match of",
+    "CLU Cross-match": "CLU cross-match",
+    "Ingest Aux": "Aux ingesting",
+    "Update Aux": "Aux updating",
+    "Filtering": "Filtering",
+    "Is Candidate": r"Checking if \w+ is Candidate",
+    "Is Source": r"Checking if \w+ is Source",
+    "Post Candidate Metadata": "Posting metadata of ",
+    "Save Source": r"Saving \w+ \w+ as a Source on SkyPortal",
+    "Make Photometry": "Making alert photometry of ",
+    "Post Photometry": "Posting photometry of ",
+    "Post Annotation": "Posting annotation for ",
+    "Get Annotation": "Getting annotations for ",
+    "Put Annotation": "Putting annotations for ",
+    "Make Thumbnail": r"Making \w+ thumbnail for",
+    "Post Thumbnail": r"Posting \w+ thumbnail for",
+    "ZTFAlert(alert)": "ZTFAlert(alert)",
+    "Prep Features": "Prepping features",
+    "braai": "braai",
+    "acai_h": "acai_h",
+    "acai_v": "acai_v",
+    "acai_o": "acai_o",
+    "acai_n": "acai_n",
+    "acai_b": "acai_b",
+    "Alert Decoding": "Decoding alert",
+    "Alert Submission": "Submitting alert",
+    "Get ZTF Instrument Id": "Getting ZTF instrument_id from SkyPortal",
+    "Get Source Groups Info": "Getting source groups info on",
+    "Get Group Info": "Getting info on group",
+}
+
+
+def generate_report(output_path, start_date, end_date):
+
+    for log_file in log_files:
+        with open(log_file) as f_l:
+            lines = f_l.readlines()
+
+        for line in lines:
+            if len(line) > 5:
+                try:
+                    tmp = line.split()
+                    t = datetime.datetime.strptime(tmp[0], "%Y%m%d_%H:%M:%S:")
+                    if start_date <= t <= end_date:
+                        # If there is exactly one 'took' in the line
+                        # This gets rid of non-timer logs but also just drops instances
+                        # where multiple timer logs were put on the same line by
+                        # multiple threads (since those are more work to parse)
+                        if len(re.findall("took", line)) == 1:
+                            # Figure out which operation is being timed
+                            for action, pattern in action_patterns.items():
+                                if re.search(pattern, line) is not None:
+                                    actions[action].append(float(tmp[-2]))
+                                    # We should only have one action per line so break out
+                                    # once we find a match
+                                    break
+
+                except Exception:
+                    continue
+
+    with PdfPages(output_path) as pdf:
+        # Add title page showing run parameters (using empty figure)
+        firstPage = plt.figure(figsize=(8.5, 11))
+        firstPage.clf()
+        start_date_str = start_date.strftime("%m / %d / %Y")
+        end_date_str = end_date.strftime("%m / %d / %Y")
+        params_text = (
+            "Kowalski Performance Report\n"
+            f"Start Date: {start_date_str}\n"
+            f"End Date: {end_date_str}\n"
+        )
+        firstPage.text(
+            0.5, 0.5, params_text, transform=firstPage.transFigure, size=24, ha="center"
+        )
+        pdf.savefig()
+        plt.close()
+
+        for i, (action, values) in enumerate(actions.items()):
+            if i % 2 == 0:
+                fig, axs = plt.subplots(2, 1)
+                fig.set_size_inches(8.5, 11)
+                fig.subplots_adjust(hspace=0.2)
+
+            if len(values) > 0:
+                actions[action] = np.array(values)
+                text = (
+                    f"median: {np.median(values):.5g}s, "
+                    f"std: {np.std(values):.5g}\n"
+                    f"min: {np.min(values):.5g}s, "
+                    f"max: {np.max(values):.5g}s\n"
+                    f"total: {np.sum(values):.5g} s / {np.sum(values)/60:.5g} min\n"
+                    f"total number of calls: {len(values)}\n"
+                )
+                ax = axs[i % 2]
+                ax.hist(
+                    values, bins=100, range=(0, np.median(values) + 3 * np.std(values))
+                )
+                ax.grid(alpha=0.4)
+                ax.set_title(action)
+                ax.set_xlabel("time (s)")
+                ax.set_ylabel("num calls")
+                ax.set_box_aspect(0.3)
+                ax.text(0.5, -0.7, text, ha="center", transform=ax.transAxes)
+
+            if i % 2 == 1:
+                pdf.savefig()
+                plt.close()
+
+            # Set report metadata
+            d = pdf.infodict()
+            d["Title"] = "Kowalski Daily Performance Summary"
+            d["Author"] = "kowalski-bot"
+            d["ModDate"] = datetime.datetime.today()
+
+
+def send_report(report_path):
+    client = WebClient(token=config["slack"]["slack_bot_token"])
+    log(f"Sending: {report_path}")
+    try:
+        response = client.files_upload(
+            channels=config["slack"]["slack_channel_id"],
+            file=report_path,
+            initial_comment="A new Kowalski performance report is ready!",
+        )
+        assert response["file"]  # the uploaded file
+    except SlackApiError as e:
+        # You will get a SlackApiError if "ok" is False
+        assert e.response["ok"] is False
+        assert e.response["error"]  # str like 'invalid_auth', 'channel_not_found'
+        log(f"Got an error: {e.response['error']}")
+
+
+def main(days_ago, send_to_slack=False):
+
+    while True:
+        try:
+            # Delete any old reports to save space
+            old_reports = list(log_dir.glob("kowalski_perf_report_*"))
+            for report in old_reports:
+                pathlib.Path.unlink(report)
+
+            # Set up new run
+            end_date = datetime.datetime.today()
+            start_date = end_date - datetime.timedelta(days=days_ago)
+            today = end_date.strftime("%Y%m%d")
+            output_file = f"kowalski_perf_report_{today}.pdf"
+            output_path = log_dir / output_file
+
+            generate_report(output_path, start_date, end_date)
+
+            if send_to_slack:
+                send_report(output_path.as_posix())
+
+        except KeyboardInterrupt:
+            log("Aborted by user")
+            sys.stderr.write("Aborted by user\n")
+            sys.exit()
+
+        except Exception as e:
+            log(str(e))
+            log(traceback.print_exc())
+
+        # Sleep for a day
+        time.sleep(86400)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--days_ago",
+        type=int,
+        default=1,
+        help="Number of days to go back to from today for collecting logs. Default 1.",
+    )
+    parser.add_argument(
+        "--send_to_slack", action="store_true", help="Send generated PDFs to Slack"
+    )
+    args = parser.parse_args()
+
+    main(args.days_ago, send_to_slack=args.send_to_slack)

--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -26,3 +26,4 @@ tensorflow==2.3.1
 tqdm>=4.54.0
 uvloop>=0.14.0
 tables>=3.6.1
+slack_sdk>=3.4.1


### PR DESCRIPTION
Example report generated from logs I transferred over to my machine from K yesterday:
[kowalski_perf_report_20210304 (1).pdf](https://github.com/dmitryduev/kowalski/files/6086712/kowalski_perf_report_20210304.1.pdf)

Screenshot of test messages to Slack:
![image](https://user-images.githubusercontent.com/17696889/110032749-83d54500-7d06-11eb-8fe0-3f887235534d.png)

Addresses #79 