### PR TITLE
Make token expiration optional and configurable

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -4,7 +4,7 @@ kowalski:
     version: "2.0.0"
     description: "Kowalski: a toolkit for Time-Domain Astronomy"
     host: "0.0.0.0"
-    port: "4000"
+    port: 4000
     admin_username: "admin"
     # fixme: use a strong password
     admin_password: "admin"

--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -12,7 +12,7 @@ kowalski:
     SECRET_KEY: "abc0123"
     JWT_SECRET_KEY: "abc0123"
     JWT_ALGORITHM: "HS256"
-    JWT_EXP_DELTA_SECONDS: 7776000
+    JWT_EXP_DELTA_SECONDS:
     # fixme: use from cryptography.fernet import Fernet; Fernet.generate_key().decode()
     fernet_key: "irjsxvfJdqSJ2fcnpPacbH972dt-RPMMLE48PQ8J5Hg="
 

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -2675,7 +2675,7 @@ async def app_factory():
     app["JWT"] = {
         "JWT_SECRET": config["server"]["JWT_SECRET_KEY"],
         "JWT_ALGORITHM": config["server"]["JWT_ALGORITHM"],
-        "JWT_EXP_DELTA_SECONDS": int(config["server"]["JWT_EXP_DELTA_SECONDS"]),
+        "JWT_EXP_DELTA_SECONDS": config["server"]["JWT_EXP_DELTA_SECONDS"],
     }
 
     # OpenAPI docs:

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -214,13 +214,15 @@ async def auth_post(request: web.Request) -> web.Response:
             # user exists and passwords match?
             select = await request.app["mongo"].users.find_one({"_id": username})
             if select is not None and check_password_hash(select["password"], password):
-                payload = {
-                    "user_id": username,
-                    "exp": datetime.datetime.utcnow()
-                    + datetime.timedelta(
-                        seconds=request.app["JWT"]["JWT_EXP_DELTA_SECONDS"]
-                    ),
-                }
+                payload = {"user_id": username}
+                # optionally set expiration date
+                if request.app["JWT"]["JWT_EXP_DELTA_SECONDS"] is not None:
+                    payload["exp"] = (
+                        datetime.datetime.utcnow()
+                        + datetime.timedelta(
+                            seconds=request.app["JWT"]["JWT_EXP_DELTA_SECONDS"]
+                        ),
+                    )
                 jwt_token = jwt.encode(
                     payload,
                     request.app["JWT"]["JWT_SECRET"],

--- a/kowalski/middlewares.py
+++ b/kowalski/middlewares.py
@@ -62,9 +62,13 @@ async def auth_middleware(request, handler) -> web.Response:
                 request.app["JWT"]["JWT_SECRET"],
                 algorithms=[request.app["JWT"]["JWT_ALGORITHM"]],
             )
-        except (jwt.DecodeError, jwt.ExpiredSignatureError):
+        except jwt.DecodeError:
             return web.json_response(
                 {"status": "error", "message": "token is invalid"}, status=400
+            )
+        except jwt.ExpiredSignatureError:
+            return web.json_response(
+                {"status": "error", "message": "token has expired"}, status=400
             )
 
         request.user = payload["user_id"]


### PR DESCRIPTION
In this PR:

- Explicitly tell the user if their token has expired.
- Set expiration date for tokens only if `JWT.JWT_EXP_DELTA_SECONDS` is set in `config.yaml`.