### PR TITLE
Updated script to fetch matchfiles from IPAC

### DIFF
--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -46,6 +46,7 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py", "ko
       "kowalski/performance_reporter.py",\
       "kowalski/requirements_ingester.txt",\
       "tests/test_ingester.py", "tests/test_tns_watcher.py", "tests/test_tools.py",\
+      "tools/fetch_ztf_matchfiles.py",\
       "tools/ingest_ztf_matchfiles.py", "tools/ingest_ztf_source_features.py",\
       "tools/istarmap.py",\
       "tools/ingest_vlass.py",\

--- a/kowalski/api.py
+++ b/kowalski/api.py
@@ -224,9 +224,9 @@ async def auth_post(request: web.Request) -> web.Response:
                         ),
                     )
                 jwt_token = jwt.encode(
-                    payload,
-                    request.app["JWT"]["JWT_SECRET"],
-                    request.app["JWT"]["JWT_ALGORITHM"],
+                    payload=payload,
+                    key=request.app["JWT"]["JWT_SECRET"],
+                    algorithm=request.app["JWT"]["JWT_ALGORITHM"],
                 )
 
                 return web.json_response({"status": "success", "token": jwt_token})

--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -2,6 +2,7 @@ aiofiles>=0.6.0
 aiohttp>=3.7.3
 astropy>=4.2
 bcrypt>=3.2.0
+beautifulsoup4>=4.9.3
 bokeh>=2.2.3
 confluent_kafka>=1.5.0
 cryptography>=3.2.1


### PR DESCRIPTION
This PR updates the script for downloading ZTF matchfiles containing persistent source light curves. The current version of the script actually does not work out of the box, so this PR addresses that.