### PR TITLE
Update ZTF matchfile ingestion script

### DIFF
--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -105,8 +105,6 @@ services:
     volumes:
       - mongodb:/data/db
     restart: always
-    networks:
-      - kowalski
     healthcheck:
       test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
       interval: 10s

--- a/tools/fetch_ztf_matchfiles.py
+++ b/tools/fetch_ztf_matchfiles.py
@@ -7,6 +7,7 @@ import pathlib
 import requests
 import subprocess
 from tqdm import tqdm
+from typing import Sequence
 from urllib.parse import urljoin
 
 from utils import load_config
@@ -72,7 +73,7 @@ def collect_urls(readout_channel: int) -> list:
     return link_list
 
 
-def fetch_url(argument_list):
+def fetch_url(argument_list: Sequence):
     """Download matchfile from IPAC's depo given its url, save to base_path"""
     # unpack arguments
     base_path, url = argument_list

--- a/tools/ingest_ztf_matchfiles.py
+++ b/tools/ingest_ztf_matchfiles.py
@@ -1,30 +1,29 @@
-import tables
-import os
-import glob
-
-# from pprint import pp
-import time
-
-# from astropy.coordinates import Angle
-import numpy as np
-import pandas as pd
-import pymongo
-import random
-import argparse
-import traceback
 import datetime
-import pytz
-from numba import jit
+import multiprocessing
 
-import istarmap  # noqa: F401
+import fire
 import multiprocessing as mp
+import numpy as np
+import os
+import pandas as pd
+import pathlib
+import pymongo
+import pytz
+import random
+import tables
+import time
 from tqdm import tqdm
+import traceback
+from typing import Sequence
 
 from utils import (
+    ccd_quad_to_rc,
     deg2dms,
     deg2hms,
-    load_config,
     init_db_sync,
+    load_config,
+    log,
+    Mongo,
 )
 
 
@@ -35,87 +34,6 @@ init_db_sync(config=config)
 
 def utc_now():
     return datetime.datetime.now(pytz.utc)
-
-
-def connect_to_db():
-    """Connect to the mongodb database
-
-    :return:
-    """
-    try:
-        if config["database"]["replica_set"] is None:
-            _client = pymongo.MongoClient(
-                host=config["database"]["host"], port=config["database"]["port"]
-            )
-        else:
-            _client = pymongo.MongoClient(
-                host=config["database"]["host"],
-                port=config["database"]["port"],
-                replicaset=config["database"]["replica_set"],
-            )
-        # grab main database:
-        _db = _client[config["database"]["db"]]
-    except Exception:
-        raise ConnectionRefusedError
-    try:
-        # authenticate
-        _db.authenticate(config["database"]["username"], config["database"]["password"])
-    except Exception:
-        raise ConnectionRefusedError
-
-    return _client, _db
-
-
-def insert_db_entry(_db, _collection=None, _db_entry=None):
-    """
-        Insert a document _doc to collection _collection in DB.
-        It is monitored for timeout in case DB connection hangs for some reason
-    :param _collection:
-    :param _db_entry:
-    :return:
-    """
-    assert _collection is not None, "Must specify collection"
-    assert _db_entry is not None, "Must specify document"
-    try:
-        _db[_collection].insert_one(_db_entry)
-    except Exception as _e:
-        print(
-            "Error inserting {:s} into {:s}".format(str(_db_entry["_id"]), _collection)
-        )
-        traceback.print_exc()
-        print(_e)
-
-
-def insert_multiple_db_entries(_db, _collection=None, _db_entries=None, _verbose=False):
-    """
-        Insert a document _doc to collection _collection in DB.
-        It is monitored for timeout in case DB connection hangs for some reason
-    :param _db:
-    :param _collection:
-    :param _db_entries:
-    :param _verbose:
-    :return:
-    """
-    assert _collection is not None, "Must specify collection"
-    assert _db_entries is not None, "Must specify documents"
-    try:
-        _db[_collection].insert_many(_db_entries, ordered=False)
-    except pymongo.errors.BulkWriteError as bwe:
-        if _verbose:
-            print(bwe.details)
-    except Exception as _e:
-        if _verbose:
-            traceback.print_exc()
-            print(_e)
-
-
-@jit(forceobj=True)
-def ccd_quad_2_rc(ccd: int, quad: int) -> int:
-    # assert ccd in range(1, 17)
-    # assert quad in range(1, 5)
-    b = (ccd - 1) * 4
-    rc = b + quad - 1
-    return rc
 
 
 filters = {"zg": 1, "zr": 2, "zi": 3}
@@ -168,87 +86,84 @@ sources_fields_to_exclude = [
 ]
 
 
-def process_file(
-    _file,
-    _collections,
-    _batch_size=2048,
-    _rm_file=False,
-    verbose=False,
-    _dry_run=False,
-):
-    # connect to MongoDB:
-    if verbose:
-        print("Connecting to DB")
-    _client, _db = connect_to_db()
-    if verbose:
-        print("Successfully connected")
-
-    if verbose:
-        print(f"processing {_file}")
+def process_file(argument_list: Sequence):
+    file_name, collections, batch_size, rm_file, dry_run = argument_list
     try:
-        with tables.open_file(_file, "r+") as f:
+        # connect to MongoDB:
+        mongo = Mongo(
+            host=config["database"]["host"],
+            port=config["database"]["port"],
+            replica_set=config["database"]["replica_set"],
+            username=config["database"]["username"],
+            password=config["database"]["password"],
+            db=config["database"]["db"],
+            verbose=0,
+        )
+
+        with tables.open_file(file_name, "r+") as f:
             group = f.root.matches
-            ff_basename = os.path.basename(_file)
+            ff_basename = pathlib.Path(file_name).name
             # base id:
-            _, field, filt, ccd, quad, _ = ff_basename.split("_")
+            _, field, filt, ccd, quadrant, _ = ff_basename.split("_")
             field = int(field)
             filt = filters[filt]
             ccd = int(ccd[1:])
-            quad = int(quad[1:])
-            rc = ccd_quad_2_rc(ccd=ccd, quad=quad)
-            baseid = int(1e13 + field * 1e9 + rc * 1e7 + filt * 1e6)
-            if verbose:
-                print(f"{_file}: baseid {baseid}")
-            exp_baseid = int(1e16 + field * 1e12 + rc * 1e10 + filt * 1e9)
+            quadrant = int(quadrant[1:])
+            readout_channel = ccd_quad_to_rc(ccd=ccd, quad=quadrant)
+            baseid = int(1e13 + field * 1e9 + readout_channel * 1e7 + filt * 1e6)
+            exposure_baseid = int(
+                1e16 + field * 1e12 + readout_channel * 1e10 + filt * 1e9
+            )
 
-            def clean_up_doc(doc):
+            def clean_up_document(document):
                 """ Format passed in dicts for Mongo insertion """
                 # convert types for pymongo:
-                for k, v in doc.items():
+                for k, v in document.items():
                     if k != "data":
                         if k in sources_int_fields:
-                            doc[k] = int(doc[k])
+                            document[k] = int(document[k])
                         else:
-                            doc[k] = float(doc[k])
+                            document[k] = float(document[k])
                             if k not in ("ra", "dec"):
-                                doc[k] = round(doc[k], 3)
+                                # this will save a lot of space:
+                                document[k] = round(document[k], 3)
 
                 # generate unique _id:
-                doc["_id"] = baseid + doc["matchid"]
-                doc["filter"] = filt
-                doc["field"] = field
-                doc["ccd"] = ccd
-                doc["quad"] = quad
-                doc["rc"] = rc
+                document["_id"] = baseid + document["matchid"]
+                document["filter"] = filt
+                document["field"] = field
+                document["ccd"] = ccd
+                document["quad"] = quadrant
+                document["rc"] = readout_channel
 
                 # GeoJSON for 2D indexing
-                doc["coordinates"] = {}
-                _ra = doc["ra"]
-                _dec = doc["dec"]
+                document["coordinates"] = dict()
+                _ra = document["ra"]
+                _dec = document["dec"]
                 _radec_str = [deg2hms(_ra), deg2dms(_dec)]
-                doc["coordinates"]["radec_str"] = _radec_str
+                document["coordinates"]["radec_str"] = _radec_str
                 # for GeoJSON, must be lon:[-180, 180], lat:[-90, 90] (i.e. in deg)
                 _radec_geojson = [_ra - 180.0, _dec]
-                doc["coordinates"]["radec_geojson"] = {
+                document["coordinates"]["radec_geojson"] = {
                     "type": "Point",
                     "coordinates": _radec_geojson,
                 }
-                doc["data"].sort(key=lambda x: x["hjd"])
-                for dd in doc["data"]:
+                document["data"].sort(key=lambda x: x["hjd"])
+                for data_point in document["data"]:
                     # convert types for pymongo:
-                    for k, v in dd.items():
+                    for k, v in data_point.items():
                         if k in sourcedata_int_fields:
-                            dd[k] = int(dd[k])
+                            data_point[k] = int(data_point[k])
                         else:
-                            dd[k] = float(dd[k])
+                            data_point[k] = float(data_point[k])
                             if k not in ("ra", "dec", "hjd"):
-                                dd[k] = round(dd[k], 3)
+                                data_point[k] = round(data_point[k], 3)
                             elif k == "hjd":
-                                dd[k] = round(dd[k], 5)
+                                data_point[k] = round(data_point[k], 5)
                     # generate unique exposure id's that match _id's in exposures collection
-                    dd["uexpid"] = exp_baseid + dd["expid"]
+                    data_point["uexpid"] = exposure_baseid + data_point["expid"]
 
-                return doc
+                return document
 
             exposures = pd.DataFrame.from_records(group.exposures[:])
             # prepare docs to ingest into db:
@@ -257,29 +172,24 @@ def process_file(
                 try:
                     doc = row.to_dict()
                     # unique exposure id:
-                    doc["_id"] = exp_baseid + doc["expid"]
+                    doc["_id"] = exposure_baseid + doc["expid"]
                     doc["matchfile"] = ff_basename
                     doc["filter"] = filt
                     doc["field"] = field
                     doc["ccd"] = ccd
-                    doc["quad"] = quad
-                    doc["rc"] = rc
+                    doc["quad"] = quadrant
+                    doc["rc"] = readout_channel
                     docs_exposures.append(doc)
-                except Exception as e_:
-                    print(str(e_))
+                except Exception as exception:
+                    log(str(exception))
 
             # ingest exposures in one go:
-            if not _dry_run:
-                if verbose:
-                    print(f"ingesting exposures for {_file}")
-                insert_multiple_db_entries(
-                    _db,
-                    _collection=_collections["exposures"],
-                    _db_entries=docs_exposures,
+            if not dry_run:
+                mongo.insert_many(
+                    collection=collections["exposures"], documents=docs_exposures
                 )
-                if verbose:
-                    print(f"done ingesting exposures for {_file}")
 
+            # light curves
             docs_sources = []
             batch_num = 1
             # fixme? skip transients
@@ -326,7 +236,7 @@ def process_file(
                         if matchid != prev_matchid:
                             # Done with last source; save
                             if current_doc is not None:
-                                current_doc = clean_up_doc(current_doc)
+                                current_doc = clean_up_document(current_doc)
                                 docs_sources.append(current_doc)
 
                             # Set up new doc
@@ -359,33 +269,29 @@ def process_file(
 
                         prev_matchid = matchid
 
-                    except Exception as e_:
-                        print(str(e_))
+                    except Exception as exception:
+                        log(str(exception))
 
                     # ingest in batches
                     try:
                         if (
-                            len(docs_sources) % _batch_size == 0
+                            len(docs_sources) % batch_size == 0
                             and len(docs_sources) != 0
                         ):
-                            if verbose:
-                                print(f"inserting batch #{batch_num} for {_file}")
-                            if not _dry_run:
-                                insert_multiple_db_entries(
-                                    _db,
-                                    _collection=_collections["sources"],
-                                    _db_entries=docs_sources,
-                                    _verbose=False,
+                            if not dry_run:
+                                mongo.insert_many(
+                                    collection=collections["sources"],
+                                    documents=docs_sources,
                                 )
                             # flush:
                             docs_sources = []
                             batch_num += 1
-                    except Exception as e_:
-                        print(str(e_))
+                    except Exception as exception:
+                        log(str(exception))
 
         # Clean up and append the last doc
         if current_doc is not None:
-            current_doc = clean_up_doc(current_doc)
+            current_doc = clean_up_document(current_doc)
             docs_sources.append(current_doc)
 
         # ingest remaining
@@ -393,87 +299,81 @@ def process_file(
             try:
                 # In case mongo crashed and disconnected, docs will accumulate in documents
                 # keep on trying to insert them until successful
-                if verbose:
-                    print(f"inserting batch #{batch_num} for {_file}")
-                if not _dry_run:
-                    insert_multiple_db_entries(
-                        _db,
-                        _collection=_collections["sources"],
-                        _db_entries=docs_sources,
-                        _verbose=False,
+                if not dry_run:
+                    mongo.insert_many(
+                        collection=collections["sources"], documents=docs_sources
                     )
                     # flush:
                     docs_sources = []
 
             except Exception as e:
                 traceback.print_exc()
-                print(e)
-                print("Failed, waiting 5 seconds to retry")
+                log(e)
+                log("Failed, waiting 5 seconds to retry")
                 time.sleep(5)
+
+        mongo.client.close()
 
     except Exception as e:
         traceback.print_exc()
-        print(e)
+        log(e)
+        # if there was an error, return without potentially deleting the file
+        return
 
-    # disconnect from db:
     try:
-        if _rm_file:
-            os.remove(_file)
-            if verbose:
-                print(f"Successfully removed {_file}")
-        _client.close()
-        if verbose:
-            if verbose:
-                print("Successfully disconnected from db")
+        if rm_file:
+            os.remove(file_name)
     finally:
         pass
 
 
-if __name__ == "__main__":
-    """ Create command line argument parser """
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter, description=""
-    )
-    parser.add_argument(
-        "--rm", action="store_true", help="remove matchfiles after ingestion?"
-    )
-    parser.add_argument("--dryrun", action="store_true", help="dry run?")
-    parser.add_argument(
-        "--np", type=int, default=96, help="number of processes for parallel ingestion"
-    )
-    parser.add_argument("--bs", type=int, default=2048, help="batch size for ingestion")
-    parser.add_argument(
-        "--tag", type=str, default="20200401", help="matchfile release time tag"
-    )
+def run(
+    path: str,
+    tag: str = "20210401",
+    num_proc: int = multiprocessing.cpu_count(),
+    batch_size: int = 2048,
+    rm: bool = False,
+    dry_run: bool = False,
+):
+    """Preprocess and Ingest ZTF matchfiles into Kowalski
 
-    args = parser.parse_args()
-
-    dry_run = args.dryrun
-    rm_file = args.rm
-
+    :param path: local path to matchfiles
+    :param tag: matchfile release time tag
+    :param num_proc: number of processes for parallel ingestion
+    :param batch_size: batch size for light curve data ingestion
+    :param rm: remove matchfiles after ingestion?
+    :param dry_run: dry run?
+    :return:
+    """
     # connect to MongoDB:
-    print("Connecting to DB")
-    client, db = connect_to_db()
-    print("Successfully connected")
-
-    t_tag = args.tag
+    log("Connecting to DB")
+    mongo = Mongo(
+        host=config["database"]["host"],
+        port=config["database"]["port"],
+        replica_set=config["database"]["replica_set"],
+        username=config["database"]["username"],
+        password=config["database"]["password"],
+        db=config["database"]["db"],
+        verbose=0,
+    )
+    log("Successfully connected to DB")
 
     collections = {
-        "exposures": f"ZTF_exposures_{t_tag}",
-        "sources": f"ZTF_sources_{t_tag}",
+        "exposures": f"ZTF_exposures_{tag}",
+        "sources": f"ZTF_sources_{tag}",
     }
 
     # create indices:
-    print("Creating indices")
+    log("Creating indices")
     if not dry_run:
-        db[collections["exposures"]].create_index(
+        mongo.db[collections["exposures"]].create_index(
             [("expid", pymongo.ASCENDING)], background=True
         )
-        db[collections["sources"]].create_index(
+        mongo.db[collections["sources"]].create_index(
             [("coordinates.radec_geojson", "2dsphere"), ("_id", pymongo.ASCENDING)],
             background=True,
         )
-        db[collections["sources"]].create_index(
+        mongo.db[collections["sources"]].create_index(
             [
                 ("field", pymongo.ASCENDING),
                 ("ccd", pymongo.ASCENDING),
@@ -481,26 +381,22 @@ if __name__ == "__main__":
             ],
             background=True,
         )
-        db[collections["sources"]].create_index(
+        mongo.db[collections["sources"]].create_index(
             [("nobs", pymongo.ASCENDING), ("_id", pymongo.ASCENDING)], background=True
         )
 
-    # number of records to insert
-    batch_size = args.bs
+    files = [str(f) for f in pathlib.Path(path).glob("ztf_*.pytable")]
 
-    _location = f"/_tmp/ztf_matchfiles_{t_tag}/"
-    files = glob.glob(os.path.join(_location, "ztf_*.pytable"))
+    log(f"# files to process: {len(files)}")
 
-    print(f"# files to process: {len(files)}")
-
-    input_list = [
-        [f, collections, batch_size, rm_file, False, dry_run] for f in sorted(files)
-    ]
+    input_list = [(f, collections, batch_size, rm, dry_run) for f in sorted(files)]
     # for a more even job distribution:
     random.shuffle(input_list)
 
-    with mp.Pool(processes=args.np) as p:
-        for _ in tqdm(p.istarmap(process_file, input_list), total=len(files)):
+    with mp.Pool(processes=num_proc) as pool:
+        for _ in tqdm(pool.imap(process_file, input_list), total=len(files)):
             pass
 
-    print("All done")
+
+if __name__ == "__main__":
+    fire.Fire(run)

--- a/tools/ingest_ztf_matchfiles.py
+++ b/tools/ingest_ztf_matchfiles.py
@@ -1,8 +1,6 @@
 import datetime
-import multiprocessing
-
 import fire
-import multiprocessing as mp
+import multiprocessing
 import numpy as np
 import os
 import pandas as pd
@@ -393,7 +391,7 @@ def run(
     # for a more even job distribution:
     random.shuffle(input_list)
 
-    with mp.Pool(processes=num_proc) as pool:
+    with multiprocessing.Pool(processes=num_proc) as pool:
         for _ in tqdm(pool.imap(process_file, input_list), total=len(files)):
             pass
 


### PR DESCRIPTION
In this PR:

- Reuse code from `utils` => -100 lines 
- Use `fire` instead of `argparse`
- Make code more robust to potential failures, e.g. if mongo falls over.
- Fix bug in `docker-compose.traefik.defaults.yaml`