### PR TITLE
Tweak TNS watcher

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -404,7 +404,7 @@ kowalski:
     password: "password"
 
   tns:
-    url: https://wis-tns.org
+    url: https://www.wis-tns.org
 
   dask:
     host: 127.0.0.1

--- a/kowalski/tns_watcher.py
+++ b/kowalski/tns_watcher.py
@@ -128,7 +128,7 @@ def get_tns(grab_all: bool = False, num_pages: int = 10, entries_per_page: int =
         )
 
         # 20210114: wis-tns.org has issues with their certificate
-        csv_data = requests.get(url, verify=False).content
+        csv_data = requests.get(url, allow_redirects=False, timeout=60).content
         data = pd.read_csv(io.StringIO(csv_data.decode("utf-8")))
 
         for index, row in data.iterrows():


### PR DESCRIPTION
The trick used previously to bypass their certificate issues now seems to be causing other problems (infinite redirect from tns-wis.org to www.tns-wis.org and back). This PR attempts to solve this issue.