### PR TITLE
Remove unnecessary code in kowalski.py::test

### DIFF
--- a/kowalski.py
+++ b/kowalski.py
@@ -519,22 +519,6 @@ class Kowalski:
             sys.exit(1)
 
         print("Testing tools")
-        # ZTF source features ingestion
-        path_ztf_source_feature = (
-            pathlib.Path(__file__).parent.absolute() / "data" / "ztf_source_features"
-        )
-        ztf_source_feature_files = list(map(str, path_ztf_source_feature.glob("*.h5")))
-        for ztf_source_feature_file in ztf_source_feature_files:
-            command = [
-                "docker",
-                "cp",
-                ztf_source_feature_file,
-                "kowalski_ingester_1:/data/",
-            ]
-            try:
-                subprocess.run(command, check=True)
-            except subprocess.CalledProcessError:
-                sys.exit(1)
         command = [
             "docker",
             "exec",


### PR DESCRIPTION
No need to copy sample ZTF source features to multiple places.