### PR TITLE
Test individual components of alert processors

### DIFF
--- a/ingester.Dockerfile
+++ b/ingester.Dockerfile
@@ -51,7 +51,10 @@ COPY ["config.yaml", "version.txt", "kowalski/generate_supervisord_conf.py", "ko
       "kowalski/dask_cluster_pgir.py",\
       "kowalski/performance_reporter.py",\
       "kowalski/requirements_ingester.txt",\
-      "tests/test_ingester.py", "tests/test_ingester_pgir.py",\
+      "tests/test_alert_broker_ztf.py",\
+      "tests/test_alert_broker_pgir.py",\
+      "tests/test_ingester.py",\
+      "tests/test_ingester_pgir.py",\
       "tests/test_tns_watcher.py", "tests/test_tools.py",\
       "tools/fetch_ztf_matchfiles.py",\
       "tools/ingest_ztf_matchfiles.py", "tools/ingest_ztf_source_features.py",\

--- a/kowalski.py
+++ b/kowalski.py
@@ -466,90 +466,67 @@ class Kowalski:
             sleep_for_seconds=10,
         )
 
-        print("Testing PGIR alert ingestion")
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_ingester_pgir.py",
+        test_setups = [
+            {
+                "part": "PGIR alert broker components",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_alert_broker_pgir.py",
+            },
+            {
+                "part": "ZTF alert broker components",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_alert_broker_ztf.py",
+            },
+            {
+                "part": "PGIR alert ingestion",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_ingester_pgir.py",
+            },
+            {
+                "part": "ZTF alert ingestion",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_ingester.py",
+            },
+            {
+                "part": "API",
+                "container": "kowalski_api_1",
+                "test_script": "test_api.py",
+            },
+            {
+                "part": "TNS monitoring",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_tns_watcher.py",
+            },
+            {
+                "part": "Tools",
+                "container": "kowalski_ingester_1",
+                "test_script": "test_tools.py",
+            },
         ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
 
-        print("Testing ZTF alert ingestion")
+        failed_tests = []
 
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_ingester.py",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
+        for setup in test_setups:
+            print(f"Testing {setup['part']}")
+            command = [
+                "docker",
+                "exec",
+                "-i",
+                setup["container"],
+                "python",
+                "-m",
+                "pytest",
+                "-s",
+                setup["test_script"],
+            ]
+            try:
+                subprocess.run(command, check=True)
+            except subprocess.CalledProcessError:
+                failed_tests.append(setup["part"])
+                continue
 
-        print("Testing API")
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_api_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_api.py",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
-
-        print("Testing TNS monitoring")
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_tns_watcher.py",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
-            sys.exit(1)
-
-        print("Testing tools")
-        command = [
-            "docker",
-            "exec",
-            "-i",
-            "kowalski_ingester_1",
-            "python",
-            "-m",
-            "pytest",
-            "-s",
-            "test_tools.py",
-        ]
-        try:
-            subprocess.run(command, check=True)
-        except subprocess.CalledProcessError:
+        if failed_tests:
+            print(f"Failed tests: {failed_tests}")
             sys.exit(1)
 
     @staticmethod

--- a/kowalski/alert_broker.py
+++ b/kowalski/alert_broker.py
@@ -431,8 +431,9 @@ class AlertWorker:
 
         return doc, prv_candidates
 
-    @staticmethod
-    def make_thumbnail(alert: Mapping, skyportal_type: str, alert_packet_type: str):
+    def make_thumbnail(
+        self, alert: Mapping, skyportal_type: str, alert_packet_type: str
+    ):
         """
         Convert lossless FITS cutouts from ZTF-like alerts into PNGs
 
@@ -443,12 +444,14 @@ class AlertWorker:
         """
         alert = deepcopy(alert)
 
-        cutout_data = alert[f"cutout{alert_packet_type}"]["stampData"]
+        cutout_data = alert[f"cutout{alert_packet_type}"]
+        if self.instrument == "ZTF":
+            cutout_data = cutout_data["stampData"]
         with gzip.open(io.BytesIO(cutout_data), "rb") as f:
             with fits.open(io.BytesIO(f.read()), ignore_missing_simple=True) as hdu:
                 # header = hdu[0].header
                 data_flipped_y = np.flipud(hdu[0].data)
-        # fixme: png, switch to fits eventually
+
         buff = io.BytesIO()
         plt.close("all")
         fig = plt.figure()
@@ -638,7 +641,7 @@ class AlertWorker:
 
         scores = dict()
 
-        if self.ml_models is None or len(self.ml_models) > 0:
+        if self.ml_models is None or len(self.ml_models) == 0:
             return dict()
 
         if self.instrument == "ZTF":

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -140,7 +140,7 @@ class ZTFAlertConsumer(AlertConsumer, ABC):
 
 class ZTFAlertWorker(AlertWorker, ABC):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(instrument="ZTF", **kwargs)
 
         # talking to SkyPortal?
         if not config["misc"]["broker"]:
@@ -372,7 +372,7 @@ class WorkerInitializer(dask.distributed.WorkerPlugin):
         self.alert_worker = None
 
     def setup(self, worker: dask.distributed.Worker):
-        self.alert_worker = ZTFAlertWorker(instrument="ZTF")
+        self.alert_worker = ZTFAlertWorker()
 
 
 def topic_listener(

--- a/kowalski/alert_broker_ztf.py
+++ b/kowalski/alert_broker_ztf.py
@@ -185,6 +185,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
         self.filter_templates = self.make_filter_templates(active_filters)
 
         # set up watchdog for periodic refresh of the filter templates, in case those change
+        self.run_forever = True
         self.filter_monitor = threading.Thread(target=self.reload_filters)
         self.filter_monitor.start()
 
@@ -308,7 +309,7 @@ class ZTFAlertWorker(AlertWorker, ABC):
 
         :return:
         """
-        while True:
+        while self.run_forever:
             time.sleep(60 * 5)
 
             active_filters = self.get_active_filters()

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -630,7 +630,6 @@ RGE = np.array(
 )
 
 
-@jit
 def radec2lb(ra, dec):
     """
         Convert $R.A.$ and $Decl.$ into Galactic coordinates $l$ and $b$

--- a/tests/test_alert_broker_pgir.py
+++ b/tests/test_alert_broker_pgir.py
@@ -1,4 +1,3 @@
-import copy
 import fastavro
 import pytest
 
@@ -74,7 +73,8 @@ class TestAlertBrokerZTF:
     def test_alert_filter__user_defined(self):
         """Test pushing an alert through a filter"""
         # prepend upstream aggregation stages:
-        pipeline = copy.deepcopy(self.worker.filter_pipeline_upstream) + [
+        upstream_pipeline = config["database"]["filters"][self.worker.collection_alerts]
+        pipeline = upstream_pipeline + [
             {
                 "$match": {
                     "candidate.drb": {"$gt": 0.5},

--- a/tests/test_alert_broker_pgir.py
+++ b/tests/test_alert_broker_pgir.py
@@ -102,4 +102,4 @@ class TestAlertBrokerZTF:
         passed_filters = self.worker.alert_filter__user_defined(
             [filter_template], self.alert
         )
-        assert len(passed_filters) == 1
+        assert passed_filters is not None

--- a/tests/test_alert_broker_pgir.py
+++ b/tests/test_alert_broker_pgir.py
@@ -1,0 +1,105 @@
+import copy
+import fastavro
+import pytest
+
+from alert_broker_pgir import PGIRAlertWorker
+from utils import load_config, log
+
+""" load config and secrets """
+config = load_config(config_file="config.yaml")["kowalski"]
+
+
+@pytest.fixture(autouse=True, scope="class")
+def worker_fixture(request):
+    log("Initializing alert processing worker class instance")
+    request.cls.worker = PGIRAlertWorker()
+    log("Successfully initialized")
+    # do not attempt monitoring filters
+    request.cls.run_forever = False
+
+
+@pytest.fixture(autouse=True, scope="class")
+def alert_fixture(request):
+    log("Loading a sample ZTF alert")
+    candid = 114297926
+    request.cls.candid = candid
+    sample_avro = f"/app/data/pgir_alerts/20210629/{candid}.avro"
+    with open(sample_avro, "rb") as f:
+        for record in fastavro.reader(f):
+            request.cls.alert = record
+    log("Successfully loaded")
+
+
+class TestAlertBrokerZTF:
+    """Test individual components/methods of the PGIR alert processor used by the broker"""
+
+    def test_alert_mongification(self):
+        """Test massaging avro packet into a dict digestible by mongodb"""
+        alert, prv_candidates = self.worker.alert_mongify(self.alert)
+        assert alert["candid"] == self.candid
+        assert len(prv_candidates) == 71
+
+    def test_make_photometry(self):
+        df_photometry = self.worker.make_photometry(self.alert)
+        assert len(df_photometry) == 71
+
+    def test_make_thumbnails(self):
+        alert, _ = self.worker.alert_mongify(self.alert)
+        for ttype, istrument_type in [
+            ("new", "Science"),
+            ("ref", "Template"),
+            ("sub", "Difference"),
+        ]:
+            thumb = self.worker.make_thumbnail(alert, ttype, istrument_type)
+            assert len(thumb.get("data", [])) > 0
+
+    def test_alert_filter__ml(self):
+        """Test executing ML models on the alert"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        scores = self.worker.alert_filter__ml(alert)
+        log(scores)
+
+    def test_alert_filter__xmatch(self):
+        """Test cross matching with external catalog"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        xmatches = self.worker.alert_filter__xmatch(alert)
+        assert len(xmatches) > 0
+
+    def test_alert_filter__xmatch_clu(self):
+        """Test cross matching with the CLU catalog"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        xmatches_clu = self.worker.alert_filter__xmatch_clu(alert)
+        assert len(xmatches_clu) > 0
+
+    def test_alert_filter__user_defined(self):
+        """Test pushing an alert through a filter"""
+        # prepend upstream aggregation stages:
+        pipeline = copy.deepcopy(self.worker.filter_pipeline_upstream) + [
+            {
+                "$match": {
+                    "candidate.drb": {"$gt": 0.5},
+                }
+            },
+            {
+                "$addFields": {
+                    "annotations.author": "dd",
+                }
+            },
+            {"$project": {"_id": 0, "candid": 1, "objectId": 1, "annotations": 1}},
+        ]
+
+        filter_template = {
+            "group_id": 1,
+            "filter_id": 1,
+            "group_name": "test_group",
+            "filter_name": "test_filter",
+            "fid": "r4nd0m",
+            "permissions": [0, 1],
+            "autosave": False,
+            "update_annotations": False,
+            "pipeline": pipeline,
+        }
+        passed_filters = self.worker.alert_filter__user_defined(
+            [filter_template], self.alert
+        )
+        assert len(passed_filters) == 1

--- a/tests/test_alert_broker_ztf.py
+++ b/tests/test_alert_broker_ztf.py
@@ -1,4 +1,3 @@
-import copy
 import fastavro
 import pytest
 
@@ -75,7 +74,8 @@ class TestAlertBrokerZTF:
     def test_alert_filter__user_defined(self):
         """Test pushing an alert through a filter"""
         # prepend upstream aggregation stages:
-        pipeline = copy.deepcopy(self.worker.filter_pipeline_upstream) + [
+        upstream_pipeline = config["database"]["filters"][self.worker.collection_alerts]
+        pipeline = upstream_pipeline + [
             {
                 "$match": {
                     "candidate.drb": {"$gt": 0.5},

--- a/tests/test_alert_broker_ztf.py
+++ b/tests/test_alert_broker_ztf.py
@@ -1,0 +1,112 @@
+import copy
+import fastavro
+import pytest
+
+from alert_broker_ztf import ZTFAlertWorker
+from utils import load_config, log
+
+""" load config and secrets """
+config = load_config(config_file="config.yaml")["kowalski"]
+
+
+@pytest.fixture(autouse=True, scope="class")
+def worker_fixture(request):
+    log("Initializing alert processing worker class instance")
+    request.cls.worker = ZTFAlertWorker()
+    log("Successfully initialized")
+    # do not attempt monitoring filters
+    request.cls.run_forever = False
+
+
+@pytest.fixture(autouse=True, scope="class")
+def alert_fixture(request):
+    log("Loading a sample ZTF alert")
+    candid = 1127561445515015011
+    request.cls.candid = candid
+    sample_avro = f"/app/data/ztf_alerts/20200202/{candid}.avro"
+    with open(sample_avro, "rb") as f:
+        for record in fastavro.reader(f):
+            request.cls.alert = record
+    log("Successfully loaded")
+
+
+class TestAlertBrokerZTF:
+    """Test individual components/methods of the ZTF alert processor used by the broker"""
+
+    def test_alert_mongification(self):
+        """Test massaging avro packet into a dict digestible by mongodb"""
+        alert, prv_candidates = self.worker.alert_mongify(self.alert)
+        assert alert["candid"] == self.candid
+        assert len(prv_candidates) == 31
+
+    def test_make_photometry(self):
+        df_photometry = self.worker.make_photometry(self.alert)
+        assert len(df_photometry) == 32
+
+    def test_make_thumbnails(self):
+        alert, _ = self.worker.alert_mongify(self.alert)
+        for ttype, istrument_type in [
+            ("new", "Science"),
+            ("ref", "Template"),
+            ("sub", "Difference"),
+        ]:
+            thumb = self.worker.make_thumbnail(alert, ttype, istrument_type)
+            assert len(thumb.get("data", [])) > 0
+
+    def test_alert_filter__ml(self):
+        """Test executing ML models on the alert"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        scores = self.worker.alert_filter__ml(alert)
+        assert len(scores) > 0
+        log(scores)
+
+    def test_alert_filter__xmatch(self):
+        """Test cross matching with external catalog"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        xmatches = self.worker.alert_filter__xmatch(alert)
+        assert len(xmatches) > 0
+
+    def test_alert_filter__xmatch_clu(self):
+        """Test cross matching with the CLU catalog"""
+        alert, _ = self.worker.alert_mongify(self.alert)
+        xmatches_clu = self.worker.alert_filter__xmatch_clu(alert)
+        assert len(xmatches_clu) > 0
+
+    def test_alert_filter__user_defined(self):
+        """Test pushing an alert through a filter"""
+        # prepend upstream aggregation stages:
+        pipeline = copy.deepcopy(self.worker.filter_pipeline_upstream) + [
+            {
+                "$match": {
+                    "candidate.drb": {"$gt": 0.5},
+                }
+            },
+            {
+                "$addFields": {
+                    "annotations.author": "dd",
+                    "annotations.mean_rb": {"$avg": "$prv_candidates.rb"},
+                }
+            },
+            {"$project": {"_id": 0, "candid": 1, "objectId": 1, "annotations": 1}},
+        ]
+        # set permissions
+        pipeline[0]["$match"]["candidate.programid"]["$in"] = [0, 1, 2, 3]
+        pipeline[3]["$project"]["prv_candidates"]["$filter"]["cond"]["$and"][0]["$in"][
+            1
+        ] = [0, 1, 2, 3]
+
+        filter_template = {
+            "group_id": 1,
+            "filter_id": 1,
+            "group_name": "test_group",
+            "filter_name": "test_filter",
+            "fid": "r4nd0m",
+            "permissions": [0, 1, 2, 3],
+            "autosave": False,
+            "update_annotations": False,
+            "pipeline": pipeline,
+        }
+        passed_filters = self.worker.alert_filter__user_defined(
+            [filter_template], self.alert
+        )
+        assert len(passed_filters) == 1

--- a/tests/test_alert_broker_ztf.py
+++ b/tests/test_alert_broker_ztf.py
@@ -109,4 +109,4 @@ class TestAlertBrokerZTF:
         passed_filters = self.worker.alert_filter__user_defined(
             [filter_template], self.alert
         )
-        assert len(passed_filters) == 1
+        assert passed_filters is not None


### PR DESCRIPTION
So far, we've only had an end-to-end alert processing and ingestion test for the broker side of Kowalski, so that every time something broke along the way, quite a bit of digging was required to sort it out and fix. This PR implements tests of the individual units that could potentially break.