### PR TITLE
Update SkyPortal annotation endpoint

### DIFF
--- a/kowalski/alert_broker.py
+++ b/kowalski/alert_broker.py
@@ -1002,7 +1002,9 @@ class AlertWorker:
                     self.verbose > 1,
                 ):
                     response = self.api_skyportal(
-                        "POST", "/api/annotation", annotations
+                        "POST",
+                        f"/api/sources/{alert['objectId']}/annotations",
+                        annotations,
                     )
                 if response.json()["status"] == "success":
                     log(f"Posted {alert['objectId']} annotation to SkyPortal")
@@ -1065,7 +1067,8 @@ class AlertWorker:
                 ):
                     response = self.api_skyportal(
                         "PUT",
-                        f"/api/annotation/{existing_annotations[origin]['annotation_id']}",
+                        f"/api/sources/{alert['objectId']}"
+                        f"/annotations/{existing_annotations[origin]['annotation_id']}",
                         annotations,
                     )
                 if response.json()["status"] == "success":

--- a/kowalski/performance_reporter.py
+++ b/kowalski/performance_reporter.py
@@ -50,7 +50,7 @@ action_patterns = {
     "Alert Submission": "Submitting alert",
     "Get ZTF Instrument Id": "Getting ZTF instrument_id from SkyPortal",
     "Get Source Groups Info": "Getting source groups info on",
-    "Get Group Info": "Getting info on group",
+    # "Get Group Info": "Getting info on group",
 }
 
 skyportal_actions = [
@@ -65,7 +65,7 @@ skyportal_actions = [
     "Post Thumbnail",
     "Get ZTF Instrument Id",
     "Get Source Groups Info",
-    "Get Group Info",
+    # "Get Group Info",
 ]
 
 


### PR DESCRIPTION
...to address the recent changes on the SP side.

Also, ditched reporting stats on "Get Group Info" in performance reporter since with alert streams from two instruments (ZTF and PGIR) in production, it dwarfs everything else with ~600k calls every night.

Depends on https://github.com/skyportal/skyportal/pull/2301.