### PR TITLE
Update docker compose version parsing

### DIFF
--- a/kowalski.py
+++ b/kowalski.py
@@ -8,6 +8,7 @@ import fire
 import pathlib
 from pprint import pprint
 import questionary
+import re
 import secrets
 import string
 import subprocess
@@ -38,7 +39,7 @@ dependencies = {
         # Command to get version
         ["docker-compose", "--version"],
         # Extract *only* the version number
-        lambda v: v.split()[2][:-1],
+        lambda v: re.search(r"\s*([\d.]+)", v).group(0),
         # It must be >= 1.22.0
         "1.22.0",
     ),

--- a/kowalski.py
+++ b/kowalski.py
@@ -39,7 +39,7 @@ dependencies = {
         # Command to get version
         ["docker-compose", "--version"],
         # Extract *only* the version number
-        lambda v: re.search(r"\s*([\d.]+)", v).group(0),
+        lambda v: re.search(r"\s*([\d.]+)", v).group(0).strip(),
         # It must be >= 1.22.0
         "1.22.0",
     ),


### PR DESCRIPTION
Prior to v2 it was something like this:

```shell
docker-compose version 1.29.1, build c34c88b2
```

which was apparently changed into something like this:

```shell
Docker Compose version v2.0.0-rc.3
```

(also now compose is a part of the docker tool, and not a standalone tool itself)