### PR TITLE
Update first install command to './kowalski.py --build'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ pip install -r requirements.txt
 
 You can then use the `kowalski.py` utility to manage `Kowalski`.
 
-### Setting config files
+### Setting up config files
 
 You need config files in order to run `Kowalski`. You can start off by copying the default config/secrets over:
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ The easiest way to interact with a `Kowalski` instance is by using a python clie
 
 ## Spin up your own `kowalski`
 
-###Cloning and Envirornment configuration
+### Cloning and Environment configuration
 
 First clone the repo and cd to the cloned directory:
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ Start off by cloning the repo, then `cd` into the cloned directory:
 git clone https://github.com/dmitryduev/kowalski.git
 cd kowalski
 ```
-Make sure you have also a python environment which meets the requirements to run `Kowalski`:
+Make sure you have a `python` environment that meets the requirements to run `Kowalski`:
 
 ```bash
 pip install -r requirements.txt

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ pip install -r requirements.txt
 Start up `Kowalski` using the default config/secrets (copying them over):
 
 ```bash
-./kowalski.py up
+./kowalski.py up --build
 ```
 
 ### Config file

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ You can do this with the following command:
 ```
 
 You have now successfully built a `Kowalski` instance!
-Any time you want to rebuild kowalski, you need to run the same command.
+Any time you want to rebuild `kowalski`, you need to re-run this command.
 
 ### Interacting with a Kowalski build
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ The easiest way to interact with a `Kowalski` instance is by using a python clie
 
 ### Cloning and Environment configuration
 
-First clone the repo and cd to the cloned directory:
+Start off by cloning the repo, then `cd` into the cloned directory:
 ```bash
 git clone https://github.com/dmitryduev/kowalski.git
 cd kowalski

--- a/readme.md
+++ b/readme.md
@@ -36,40 +36,66 @@ The easiest way to interact with a `Kowalski` instance is by using a python clie
 
 ## Spin up your own `kowalski`
 
-Clone the repo and cd to the cloned directory:
+###Cloning and Envirornment configuration
+
+First clone the repo and cd to the cloned directory:
 ```bash
 git clone https://github.com/dmitryduev/kowalski.git
 cd kowalski
 ```
-
-Use the `kowalski.py` utility to manage `Kowalski`.
-
-Make sure the requirements to run the `kowalski.py` utility are met, e.g.:
+Make sure you have also a python environment which meets the requirements to run `Kowalski`:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Start up `Kowalski` using the default config/secrets (copying them over):
+You can then use the `kowalski.py` utility to manage `Kowalski`.
+
+### Setting config files
+
+You need config files in order to run `Kowalski`. You can start off by copying the default config/secrets over:
+
+```bash
+cp config.defaults.yaml config.yaml
+cp docker-compose.defaults.yaml docker-compose.yaml
+```
+
+`config.yaml` contains the API and ingester configs, the `supevisord` config for the API and ingester containers,
+together with all the secrets, so be careful when committing code / pushing docker images.
+
+However, if you want to run in a production setting, be sure to modify `config.yaml` and choose strong passwords!
+
+`docker-compose.yaml` serves as a config file for `docker-compose`, and can be used for different Kowalski deployment modes.
+Kowalski comes with several possible default `docker-compose` configs (see [below](#different-deployment-scenarios) for more info).
+
+### Building Kowalski
+
+Finally, once you've set the config files, you can actually build an instance of Kowalski.
+You can do this with the following command:
 
 ```bash
 ./kowalski.py up --build
 ```
 
-### Config file
+You have now successfully built a `Kowalski` instance!
+Any time you want to rebuild kowalski, you need to run the same command.
 
-You should `cp config.defaults.yaml config.yaml` instead of using the default config in a production setting.
-Make sure to choose strong passwords!
+### Interacting with a Kowalski build
 
-`config.yaml` contains the API and ingester configs, the `supevisord` config for the API and ingester containers,
-together with all the secrets, so be careful when committing code / pushing docker images.
+If you want to just interact with a `Kowalski` instance that has already been built, you can drop the `--build` flag:
 
+* `./kowalski.py up` to start up a pre-built Kowalski instance
+* `./koiwalski.py down`to shut down a pre-built Kowalski instance
 
-### Deployment scenarios
+## Run tests
+
+You can check that a running `Kowalski` instance is working by using the Kowalski test suite:
 
 ```bash
-./kowalski.py up
+./kowalski.py test
 ```
+
+## Different Deployment scenarios
 
 `Kowalski` uses `docker-compose` under the hood and requires a `docker-compose.yaml` file.
 There are several available deployment scenarios:
@@ -78,19 +104,19 @@ There are several available deployment scenarios:
 - Bare-bones + broker for `SkyPortal` / `Fritz`
 - Behind `traefik`
 
-#### Bare-bones
+### Bare-bones
 
 Use `docker-compose.defaults.yaml` as a template for `docker-compose.yaml`.
 Note that the environment variables for the `mongo` service must match
 `admin_*` under `kowalski.database` in `config.yaml`.
 
-#### Bare-bones + broker for [`SkyPortal`](https://skyportal.io/) / [`Fritz`](https://github.com/fritz-marshal/fritz)
+### Bare-bones + broker for [`SkyPortal`](https://skyportal.io/) / [`Fritz`](https://github.com/fritz-marshal/fritz)
 
 Use `docker-compose.fritz.defaults.yaml` as a template for `docker-compose.yaml`.
 If you want the alert ingester to post (filtered) alerts to `SkyPortal`, make sure
 `{"misc": {"broker": true}}` in `config.yaml`.
 
-#### Behind `traefik`
+### Behind `traefik`
 
 Use `docker-compose.traefik.defaults.yaml` as a template for `docker-compose.yaml`.
 
@@ -102,13 +128,6 @@ getting a TLS certificate from `letsencrypt`.
 In `docker-compose.yaml`:
 - Replace `kowalski@caltech.edu` with your email.
 - Replace `private.caltech.edu` with your domain.
-
-
-## Run tests
-
-```bash
-./kowalski.py test
-```
 
 ## Shut down `Kowalski`
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ together with all the secrets, so be careful when committing code / pushing dock
 However, if you want to run in a production setting, be sure to modify `config.yaml` and choose strong passwords!
 
 `docker-compose.yaml` serves as a config file for `docker-compose`, and can be used for different Kowalski deployment modes.
-Kowalski comes with several possible default `docker-compose` configs (see [below](#different-deployment-scenarios) for more info).
+Kowalski comes with several template `docker-compose` configs (see [below](#different-deployment-scenarios) for more info).
 
 ### Building Kowalski
 

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ Kowalski comes with several template `docker-compose` configs (see [below](#diff
 
 ### Building Kowalski
 
-Finally, once you've set the config files, you can actually build an instance of Kowalski.
+Finally, once you've set the config files, you can build an instance of Kowalski.
 You can do this with the following command:
 
 ```bash


### PR DESCRIPTION
When starting up your own local version of kowalski, the first time installation instructions are a little misleading. You need to run `./kowalski.py up --build`, not `./kowalski.py up`. This PR updates the readme.md to adopt this new command instead.