### PR TITLE
Pin protobuf in requirements

### DIFF
--- a/kowalski/requirements_ingester.txt
+++ b/kowalski/requirements_ingester.txt
@@ -16,6 +16,7 @@ motor==2.5.1
 numba==0.55.2
 numpy==1.21.6
 pandas==1.3.2
+protobuf==3.20.*
 pyarrow==5.0.0
 pyjwt==2.4.0
 pymongo==3.12.0


### PR DESCRIPTION
A recent bump in tensorflow appears to have broken the ingestor with errors described here:

https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly/72493690#72493690

This PR pins protobuf to address it.