### PR TITLE
add logging to file

### DIFF
--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -62,7 +62,7 @@ import traceback
 from typing import Optional, Sequence
 import yaml
 
-LOG_DIR = os.getenv('KOWALSKI_LOG_DIR', '/app/logs')
+LOG_DIR = os.getenv('KOWALSKI_LOG_DIR', './logs')
 
 pi = 3.141592653589793
 

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -108,7 +108,7 @@ def time_stamp():
 
 def log(message):
     timestamp = time_stamp()
-    print(f"{time}: {message}")
+    print(f"{timestamp}: {message}")
 
     if not os.path.isdir(LOG_DIR):
         os.mkdir(LOG_DIR)

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -62,7 +62,7 @@ import traceback
 from typing import Optional, Sequence
 import yaml
 
-LOG_DIR = os.getenv('KOWALSKI_LOG_DIR', './logs')
+LOG_DIR = os.getenv("KOWALSKI_LOG_DIR", "./logs")
 
 pi = 3.141592653589793
 

--- a/kowalski/utils.py
+++ b/kowalski/utils.py
@@ -62,6 +62,7 @@ import traceback
 from typing import Optional, Sequence
 import yaml
 
+LOG_DIR = os.getenv('KOWALSKI_LOG_DIR', '/app/logs')
 
 pi = 3.141592653589793
 
@@ -106,7 +107,16 @@ def time_stamp():
 
 
 def log(message):
-    print(f"{time_stamp()}: {message}")
+    timestamp = time_stamp()
+    print(f"{time}: {message}")
+
+    if not os.path.isdir(LOG_DIR):
+        os.mkdir(LOG_DIR)
+
+    date = timestamp.split("_")[0]
+    with open(os.path.join(LOG_DIR, f"kowalski_{date}.log"), "a") as logfile:
+        logfile.write(f"{timestamp}: {message}\n")
+        logfile.flush()
 
 
 def forgiving_true(expression):


### PR DESCRIPTION
This PR adds some functionality to the `utils.log()` function. 
It will try to find a logging folder using an environmental variable `KOWALSKI_LOG_DIR` and default to `./logs` if it doesn't find it. 

In that file the app will generate a different log file for every day called `kowalski_YYMMDD.log` and append the output to that file. 